### PR TITLE
Make camel case rule stricter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "array-bracket-spacing": [ "error", "always" ],
     "block-spacing": "error",
     "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
-    "camelcase": [ "error", { "properties": "never" } ],
+    "camelcase": [ "error", { "properties": "always" } ],
     "comma-dangle": [ "error", "never" ],
     "comma-spacing": [ "error", { "before": false, "after": true } ],
     "comma-style": [ "error", "last" ],


### PR DESCRIPTION
Our existing jscs rule is this stricter than this (is also disables leading underscores, which eslint can't do) so we should try to match it.

https://phabricator.wikimedia.org/T149261
