### PR TITLE
Add no-sparse-arrays rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
     "no-new": "error",
     "no-new-func": "error",
     "no-spaced-func": "error",
+    "no-sparse-arrays": "error",
     "no-trailing-spaces": "error",
     "no-undef": "error",
     "no-underscore-dangle": "error",


### PR DESCRIPTION
[ 3, , 4 ] is usually a typo and we had this rule in jshint.

https://phabricator.wikimedia.org/T149262
