### PR TITLE
Require space before parens in anonymous functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,7 +59,7 @@
     "semi": [ "error", "always" ],
     "semi-spacing": [ "error", { "before": false, "after": true } ],
     "space-before-blocks": [ "error", "always" ],
-    "space-before-function-paren": [ "error", { "anonymous": "ignore", "named": "never" } ],
+    "space-before-function-paren": [ "error", { "anonymous": "always", "named": "never" } ],
     "space-in-parens": [ "error", "always", { "exceptions": [ "empty" ] } ],
     "space-infix-ops": "error",
     "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],


### PR DESCRIPTION
This was previously enforced in JSCS, but for some reason we set it to ignore here.