### PR TITLE
Remove dot-notation/allowKeywords override

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
     "computed-property-spacing": [ "error", "always" ],
     "curly": [ "error", "all" ],
     "dot-location": [ "error", "property" ],
-    "dot-notation": [ "error", { "allowKeywords": false } ],
+    "dot-notation": [ "error" ],
     "eol-last": "error",
     "eqeqeq": "error",
     "func-call-spacing": "error",

--- a/test/fixtures/invalid-results.json
+++ b/test/fixtures/invalid-results.json
@@ -25,6 +25,11 @@
 		"ruleId": "no-constant-condition"
 	},
 	{
+		"line": 27,
+		"column": 24,
+		"ruleId": "dot-notation"
+	},
+	{
 		"line": 29,
 		"column": 15,
 		"ruleId": "no-negated-in-lhs"

--- a/test/fixtures/invalid.js
+++ b/test/fixtures/invalid.js
@@ -23,8 +23,8 @@ var APP;
 		// eslint-disable-next-line no-constant-condition
 		if ( true || options.quux ) {
 			name += options.quux;
-		// eslint-disable-next-line no-empty
-		} else if ( options.quux ) {
+		// eslint-disable-next-line no-empty, dot-notation
+		} else if ( options[ 'default' ] ) {
 		// eslint-disable-next-line no-negated-in-lhs, no-unsafe-negation
 		} else if ( !'default' in options ) {
 			// eslint-disable-next-line no-use-before-define

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -43,11 +43,11 @@
 		// Rule: space-before-blocks
 		if ( options.quux ) {
 			name += options.quux;
-		} else if ( options.quux ) {
-			name += options.quux;
+		} else if ( options.default ) {
+			name += options.default;
 		// Rule: computed-property-spacing
-		} else if ( options[ 'default' ] ) {
-			name += 'default';
+		} else if ( options[ 'property-name' ] ) {
+			name += 'property-name';
 		}
 
 		// Rule: operator-linebreak


### PR DESCRIPTION
This rule is for ES3 compatibility, and this ruleset is for ES5 code.