### PR TITLE
Extend valid-jsdoc rule to validate use of @return

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -86,7 +86,7 @@
     "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
     "spaced-comment": [ "error", "always", { "exceptions": [ "*", "!" ] } ],
     "unicode-bom": [ "error" ],
-    "valid-jsdoc": [ "error", { "requireParamDescription": false, "requireReturnDescription": false, "requireReturn": false } ],
+    "valid-jsdoc": [ "error", { "requireParamDescription": false, "requireReturnDescription": false, "requireReturn": false, "prefer": { "returns": "return" } } ],
     "vars-on-top": "error",
     "wrap-iife": "error",
     "yoda": [ "error", "never" ]

--- a/test/fixtures/invalid-results.json
+++ b/test/fixtures/invalid-results.json
@@ -288,5 +288,15 @@
 		"line": 200,
 		"column": 19,
 		"ruleId": "no-implicit-coercion"
+	},
+	{
+		"line": 207,
+		"column": 2,
+		"ruleId": "valid-jsdoc"
+	},
+	{
+		"line": 217,
+		"column": 2,
+		"ruleId": "valid-jsdoc"
 	}
 ]

--- a/test/fixtures/invalid.js
+++ b/test/fixtures/invalid.js
@@ -203,4 +203,23 @@ var APP;
 
 	global.APP = APP;
 
+	// eslint-disable-next-line valid-jsdoc
+	/**
+	 * @param {number} a
+	 * @param {number} b
+	 * @returns {undefined}
+	 */
+	APP.sum = function ( a, b ) {
+		return a + b;
+	};
+
+	// eslint-disable-next-line valid-jsdoc
+	/**
+	 * @param {number} a
+	 * @return {undefined}
+	 */
+	APP.multiply = function ( a, b ) {
+		return a * b;
+	};
+
 }( this ) );

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -155,6 +155,15 @@
 		}
 	};
 
+	/**
+	 * @param {number} a
+	 * @param {number} b
+	 * @return {number}
+	 */
+	APP.sum = function ( a, b ) {
+		return a + b;
+	};
+
 	APP.cast = function ( options, val ) {
 		options.enable = !!val;
 		options.disable = Boolean( val );


### PR DESCRIPTION
Enforce consistent use of `@returns` instead of `@return` (since JSDuck supports both).

Added two test cases:

* Unexpected `@returns`, use `@return` instead.
* Missing documentation for `b`.

/cc @catrope @jdforrester 