### PR TITLE
New rule: `max-len` - Enforce 100 character line length

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,16 @@
     "key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ],
     "keyword-spacing": "error",
     "linebreak-style": [ "error", "unix" ],
+    "max-len": [ "warn", {
+      "code": 100,
+      "tabWidth": 4,
+      "ignorePattern": "^// eslint-.+",
+      "ignoreUrls": true,
+      "ignoreComments": false,
+      "ignoreRegExpLiterals": true,
+      "ignoreStrings": true,
+      "ignoreTemplateLiterals": true
+    } ],
     "new-cap": [ "error", { "newIsCap": true, "capIsNew": false, "properties": true } ],
     "new-parens": "error",
     "no-alert": "error",

--- a/test/fixtures/invalid-es5.js
+++ b/test/fixtures/invalid-es5.js
@@ -78,6 +78,9 @@ var APP;
 		// eslint-disable-next-line no-new-wrappers
 		bar = new String( 'events' );
 
+		// eslint-disable-next-line max-len
+		// This is a ludicrously long comment that is so long that one can't help but wonder as to whether the writer is a fool or merely testing other developers.
+
 		// eslint-disable-next-line no-new
 		new APP.Example();
 

--- a/test/fixtures/invalid-results.json
+++ b/test/fixtures/invalid-results.json
@@ -88,13 +88,13 @@
 			"filename": "fixtures/invalid-es5.js",
 			"line": 58,
 			"column": 4,
-			"ruleId": "no-inner-declarations"
+			"ruleId": "no-loop-func"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
 			"line": 58,
 			"column": 4,
-			"ruleId": "no-loop-func"
+			"ruleId": "no-inner-declarations"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
@@ -153,252 +153,258 @@
 		{
 			"filename": "fixtures/invalid-es5.js",
 			"line": 82,
-			"column": 3,
-			"ruleId": "no-new"
+			"column": 1,
+			"ruleId": "max-len"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
 			"line": 85,
 			"column": 3,
+			"ruleId": "no-new"
+		},
+		{
+			"filename": "fixtures/invalid-es5.js",
+			"line": 88,
+			"column": 3,
 			"ruleId": "no-with"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 87,
+			"line": 90,
 			"column": 10,
 			"ruleId": "no-void"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 89,
+			"line": 92,
 			"column": 10,
 			"ruleId": "no-proto"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 91,
+			"line": 94,
 			"column": 10,
 			"ruleId": "no-self-compare"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 95,
+			"line": 98,
 			"column": 26,
 			"ruleId": "no-trailing-spaces"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 98,
+			"line": 101,
 			"column": 3,
 			"ruleId": "no-underscore-dangle"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 101,
+			"line": 104,
 			"column": 3,
 			"ruleId": "no-whitespace-before-property"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 105,
+			"line": 108,
 			"column": 8,
 			"ruleId": "no-undef-init"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 111,
+			"line": 114,
 			"column": 8,
 			"ruleId": "no-shadow-restricted-names"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 116,
+			"line": 119,
 			"column": 9,
 			"ruleId": "no-useless-call"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 119,
+			"line": 122,
 			"column": 11,
 			"ruleId": "no-unmodified-loop-condition"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 127,
+			"line": 130,
 			"column": 4,
 			"ruleId": "no-extra-bind"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 133,
+			"line": 136,
 			"column": 11,
 			"ruleId": "no-caller"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 136,
+			"line": 139,
 			"column": 3,
 			"ruleId": "no-label-var"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 136,
+			"line": 139,
 			"column": 8,
 			"ruleId": "for-direction"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 140,
+			"line": 143,
 			"column": 11,
 			"ruleId": "no-extra-label"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 143,
+			"line": 146,
 			"column": 5,
 			"ruleId": "no-throw-literal"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 153,
+			"line": 156,
 			"column": 13,
 			"ruleId": "switch-colon-spacing"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 153,
+			"line": 156,
 			"column": 13,
 			"ruleId": "switch-colon-spacing"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 153,
+			"line": 156,
 			"column": 20,
 			"ruleId": "semi-spacing"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 155,
-			"column": 1,
-			"ruleId": "indent"
-		},
-		{
-			"filename": "fixtures/invalid-es5.js",
-			"line": 157,
-			"column": 1,
-			"ruleId": "indent"
-		},
-		{
-			"filename": "fixtures/invalid-es5.js",
 			"line": 158,
+			"column": 1,
+			"ruleId": "indent"
+		},
+		{
+			"filename": "fixtures/invalid-es5.js",
+			"line": 160,
+			"column": 1,
+			"ruleId": "indent"
+		},
+		{
+			"filename": "fixtures/invalid-es5.js",
+			"line": 161,
 			"column": 5,
 			"ruleId": "semi-style"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 165,
+			"line": 168,
 			"column": 20,
 			"ruleId": "new-cap"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 167,
+			"line": 170,
 			"column": 3,
 			"ruleId": "no-return-assign"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 171,
+			"line": 174,
 			"column": 2,
 			"ruleId": "no-extend-native"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 176,
-			"column": 2,
-			"ruleId": "no-implicit-globals"
-		},
-		{
-			"filename": "fixtures/invalid-es5.js",
-			"line": 176,
-			"column": 2,
-			"ruleId": "no-native-reassign"
-		},
-		{
-			"filename": "fixtures/invalid-es5.js",
-			"line": 176,
+			"line": 179,
 			"column": 2,
 			"ruleId": "no-global-assign"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
 			"line": 179,
+			"column": 2,
+			"ruleId": "no-implicit-globals"
+		},
+		{
+			"filename": "fixtures/invalid-es5.js",
+			"line": 179,
+			"column": 2,
+			"ruleId": "no-native-reassign"
+		},
+		{
+			"filename": "fixtures/invalid-es5.js",
+			"line": 182,
 			"column": 18,
 			"ruleId": "no-multi-spaces"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 181,
+			"line": 184,
 			"column": 12,
 			"ruleId": "no-floating-decimal"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 183,
+			"line": 186,
 			"column": 13,
 			"ruleId": "no-multi-str"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 186,
+			"line": 189,
 			"column": 1,
 			"ruleId": "no-multiple-empty-lines"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 190,
+			"line": 193,
 			"column": 15,
 			"ruleId": "no-useless-concat"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 192,
+			"line": 195,
 			"column": 10,
 			"ruleId": "no-octal-escape"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 194,
+			"line": 197,
 			"column": 11,
 			"ruleId": "no-script-url"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 196,
+			"line": 199,
 			"column": 23,
 			"ruleId": "no-unneeded-ternary"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 207,
+			"line": 210,
 			"column": 19,
 			"ruleId": "no-implicit-coercion"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 214,
+			"line": 217,
 			"column": 6,
 			"ruleId": "valid-jsdoc"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 220,
+			"line": 223,
 			"column": 2,
 			"ruleId": "valid-jsdoc"
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
-			"line": 229,
+			"line": 232,
 			"column": 27,
 			"ruleId": "no-prototype-builtins"
 		}

--- a/test/fixtures/valid-es5.js
+++ b/test/fixtures/valid-es5.js
@@ -1,6 +1,7 @@
 /* eslint-env es5 */
 
 // Rule: linebreak-style
+// Rule: max-len
 // Rule: wrap-iife
 // Rule: semi
 // Rule: semi-spacing
@@ -36,6 +37,9 @@
 	 */
 	APP.Example = function ( id, options ) {
 		var name, inline, bar;
+
+		// Rule: max-len
+		bar = 'This is a long string that is indeed so long that it breaches the line length rules and thus would trigger a warning were it not for the over-ride.';
 
 		// Rule: space-infix-ops
 		this.total = upHere() + id;


### PR DESCRIPTION
Ignore:

* lines with eslint directives as they usually go over 80 because of the
  directive
* ignore long URLs
* ignore strings as it hurts readability on test files, assertions, and
  other strings that are hard to break

See https://phabricator.wikimedia.org/T185295 for more context and discussion.