### PR TITLE
Update ESLint to version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "license": "MIT",
   "devDependencies": {
     "assert-diff": "^1.2.0",
-    "eslint": "^3.1.1"
+    "eslint": "^4.9.0"
   }
 }

--- a/test/fixtures/invalid-results.json
+++ b/test/fixtures/invalid-results.json
@@ -21,7 +21,7 @@
 	},
 	{
 		"line": 24,
-		"column": 3,
+		"column": 8,
 		"ruleId": "no-constant-condition"
 	},
 	{
@@ -81,12 +81,12 @@
 	},
 	{
 		"line": 65,
-		"column": 4,
+		"column": 3,
 		"ruleId": "no-unused-expressions"
 	},
 	{
 		"line": 65,
-		"column": 7,
+		"column": 6,
 		"ruleId": "no-sequences"
 	},
 	{
@@ -206,12 +206,12 @@
 	},
 	{
 		"line": 150,
-		"column": 3,
+		"column": 1,
 		"ruleId": "indent"
 	},
 	{
 		"line": 152,
-		"column": 4,
+		"column": 1,
 		"ruleId": "indent"
 	},
 	{
@@ -291,11 +291,11 @@
 	},
 	{
 		"line": 207,
-		"column": 2,
+		"column": 6,
 		"ruleId": "valid-jsdoc"
 	},
 	{
-		"line": 217,
+		"line": 213,
 		"column": 2,
 		"ruleId": "valid-jsdoc"
 	}

--- a/test/fixtures/invalid.js
+++ b/test/fixtures/invalid.js
@@ -61,8 +61,8 @@ var APP;
 
 		// eslint-disable-next-line no-unused-labels
 		data:
-			// eslint-disable-next-line no-unused-expressions, no-sequences
-			bar, named();
+		// eslint-disable-next-line no-unused-expressions, no-sequences
+		bar, named();
 
 		// eslint-disable-next-line no-array-constructor
 		bar = new Array();
@@ -148,7 +148,7 @@ var APP;
 		switch ( code ) {
 		// eslint-disable-next-line indent
 		case 200:
-		// eslint-disable-next-line indent
+			// eslint-disable-next-line indent
 			break;
 		}
 	};
@@ -204,13 +204,9 @@ var APP;
 	global.APP = APP;
 
 	// eslint-disable-next-line valid-jsdoc
-	/**
-	 * @param {number} a
-	 * @param {number} b
-	 * @returns {undefined}
-	 */
-	APP.sum = function ( a, b ) {
-		return a + b;
+	/** @returns {undefined} */
+	APP.stop = function () {
+		return '@returns instead of @return';
 	};
 
 	// eslint-disable-next-line valid-jsdoc
@@ -219,7 +215,7 @@ var APP;
 	 * @return {undefined}
 	 */
 	APP.multiply = function ( a, b ) {
-		return a * b;
+		return a * b.undocumented;
 	};
 
 }( this ) );

--- a/test/invalid.js
+++ b/test/invalid.js
@@ -42,7 +42,7 @@ for ( rule in config.rules ) {
 		count++;
 		assert(
 			fixture.match( new RegExp(
-				'(//|/\*) eslint-disable(-next-line)? ([a-z-]+, )??' + rule
+				'(//|/*) eslint-disable(-next-line)? ([a-z-]+, )??' + rule
 			) ),
 			'Rule ' + rule + ' is covered'
 		);


### PR DESCRIPTION
We already use ESLint 4.9.0 in mediawiki/core, but this repo
was still using eslint 3.x in its own tests.

Looks like a couple have things have changed in ESLint that we
should be aware of.

* ESLint 4.0.0 added 'no-useless-escape' to eslint:recommends,
  which we violated at test/invalid.js:45:11.
  Fixed.

* Indention rules have changed slightly. Only affected cases where
  the purpose of the line was *not* about indentation, so just
  fix the fixture to reflect current rule.

* Simplify test fixture for `valid-jsdoc/@returns`.
  At some point between eslint 3.1.1 and 4.19.0, the logic between
  "disable-next-line" and the "valid-jsdoc" broke.
  The valid-jsdoc rule was improved to have better line numbers,
  and now it can't be disabled before a multi-line comment.
  Filed upstream: https://github.com/eslint/eslint/issues/10095.
  Workaround: Use single-line doc comment for this case.

* Update invalid-results.json.