### PR TITLE
New rule: `qunit/require-expect` (Fixes #85)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -418,9 +418,9 @@
       }
     },
     "eslint-plugin-qunit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-3.2.1.tgz",
-      "integrity": "sha1-Bs1GjVmMobomNLFJwAA0mZfdQ8I=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-3.3.1.tgz",
+      "integrity": "sha512-entAEwuXE1GU9NaOAJkufuDszOmGWDnNvmY7AP64GZFB55mg2UivCz6//UKFVjvtjQRYW37OLIoIks4ajG4BRA==",
       "dev": true
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Gaidarenko Oleg <markelog@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "eslint-plugin-qunit": "^3.2.1"
+    "eslint-plugin-qunit": "^3.3.0"
   },
   "devDependencies": {
     "assert-diff": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "devDependencies": {
     "assert-diff": "^1.2.0",
     "eslint": "^5.0.0",
-    "eslint-plugin-qunit": "^3.2.1"
+    "eslint-plugin-qunit": "^3.3.0"
   }
 }

--- a/qunit.json
+++ b/qunit.json
@@ -9,6 +9,6 @@
     "qunit/no-assert-equal": "error",
     "qunit/no-early-return": "error",
     "qunit/no-negated-ok": "error",
-    "qunit/require-expect": "off"
+    "qunit/require-expect": [ "error", "never-except-zero" ]
   }
 }


### PR DESCRIPTION
Requires upgrading to eslint-plugin-qunit 3.3.0+ to provide our
desired configuration option, 'never-except-zero'.