### PR TITLE
Changed rule: `quotes` – Add the 'avoidEscape' option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -85,7 +85,7 @@
     "operator-linebreak": [ "error", "after" ],
     "prefer-numeric-literals": "error",
     "quote-props": [ "error", "as-needed", { "keywords": true } ],
-    "quotes": [ "error", "single" ],
+    "quotes": [ "error", "single", { "avoidEscape": true } ],
     "semi": [ "error", "always" ],
     "semi-spacing": [ "error", { "before": false, "after": true } ],
     "semi-style": [ "error", "last" ],

--- a/test/fixtures/invalid-es5.js
+++ b/test/fixtures/invalid-es5.js
@@ -68,8 +68,8 @@ var APP;
 
 		// eslint-disable-next-line no-array-constructor
 		bar = new Array();
-		// eslint-disable-next-line no-new-func
-		bar = new Function( 'a', 'return ' + name + ';' );
+		// eslint-disable-next-line no-new-func, quotes
+		bar = new Function( 'a', "return " + name + ";" );
 		// eslint-disable-next-line no-new-object
 		bar = new Object();
 		// eslint-disable-next-line no-new-require, new-cap

--- a/test/fixtures/invalid-results.json
+++ b/test/fixtures/invalid-results.json
@@ -116,6 +116,18 @@
 		},
 		{
 			"filename": "fixtures/invalid-es5.js",
+			"line": 0,
+			"column": 28,
+			"ruleId": "quotes"
+		},
+		{
+			"filename": "fixtures/invalid-es5.js",
+			"line": 0,
+			"column": 47,
+			"ruleId": "quotes"
+		},
+		{
+			"filename": "fixtures/invalid-es5.js",
 			"line": 2,
 			"column": 9,
 			"ruleId": "no-new-object"

--- a/test/fixtures/valid-es5.js
+++ b/test/fixtures/valid-es5.js
@@ -205,7 +205,9 @@
 			value: {
 				of: 'I don\'t know'
 			}
-		}
+		},
+		// Rule: quotes
+		fourth: "Who's coming to tea?"
 	} );
 
 	APP.example( 'banana' )

--- a/test/testInvalid.js
+++ b/test/testInvalid.js
@@ -56,7 +56,8 @@ console.log( 'Verified ' + ( results[ 0 ].length + results[ 1 ].length ) + ' exp
 // Verify coverage
 count = 0;
 testPositives = [
-	'arrow-parens' // Has an invalid test case
+	'arrow-parens', // Has an invalid test case
+	'quotes' // Has an invalid test case
 ];
 Object.keys( config.rules ).concat( Object.keys( configQUnit.rules ) ).forEach( function ( rule ) {
 	var rDisableRule = new RegExp( '(//|/*) eslint-disable(-next-line)? ([a-z-]+, )??' + rule );


### PR DESCRIPTION
Proposed during review of wikimedia/eslint-config-node-services/pull/29.