### PR TITLE
Install jQuery plugin via GitHub to avoid rule prefix

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -2,14 +2,14 @@
   "globals": {
     "$": false
   },
-  "plugins": [ "@wikimedia/jquery" ],
+  "plugins": [ "jquery" ],
   "rules": {
-    "@wikimedia/jquery/no-each-util": "error",
-    "@wikimedia/jquery/no-grep": "error",
-    "@wikimedia/jquery/no-in-array": "error",
-    "@wikimedia/jquery/no-is-function": "error",
-    "@wikimedia/jquery/no-map-util": "error",
-    "@wikimedia/jquery/no-proxy": "error",
-    "@wikimedia/jquery/no-trim": "error"
+    "jquery/no-each-util": "error",
+    "jquery/no-grep": "error",
+    "jquery/no-in-array": "error",
+    "jquery/no-is-function": "error",
+    "jquery/no-map-util": "error",
+    "jquery/no-proxy": "error",
+    "jquery/no-trim": "error"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@wikimedia/eslint-plugin-jquery": {
-      "version": "1.3.2-wmf.1",
-      "resolved": "https://registry.npmjs.org/@wikimedia/eslint-plugin-jquery/-/eslint-plugin-jquery-1.3.2-wmf.1.tgz",
-      "integrity": "sha512-gpGMhOAuV8wUFkyJtuJOlnPxjfr5LdslqxTJzibTYWFY9W956I/w13bPg45MbptzcjNSiusrckZ0wS2t+awrqg==",
-      "dev": true
-    },
     "acorn": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
@@ -311,6 +305,11 @@
         "table": "^5.0.2",
         "text-table": "^0.2.0"
       }
+    },
+    "eslint-plugin-jquery": {
+      "version": "github:wikimedia/eslint-plugin-jquery#2fa39abd3c8167bde49841a726794359416c1bd3",
+      "from": "github:wikimedia/eslint-plugin-jquery#v1.3.2-wmf.1",
+      "dev": true
     },
     "eslint-plugin-qunit": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "assert-diff": "^2.0.3",
     "eslint": "^5.9.0",
-    "@wikimedia/eslint-plugin-jquery": "1.3.2-wmf.1",
+    "eslint-plugin-jquery": "wikimedia/eslint-plugin-jquery#v1.3.2-wmf.1",
     "eslint-plugin-qunit": "^4.0.0"
   }
 }

--- a/test/fixtures/jquery/invalid-results.json
+++ b/test/fixtures/jquery/invalid-results.json
@@ -4,43 +4,43 @@
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 6,
 			"column": 2,
-			"ruleId": "@wikimedia/jquery/no-each-util"
+			"ruleId": "jquery/no-each-util"
 		},
 		{
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 3,
 			"column": 2,
-			"ruleId": "@wikimedia/jquery/no-grep"
+			"ruleId": "jquery/no-grep"
 		},
 		{
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 3,
 			"column": 2,
-			"ruleId": "@wikimedia/jquery/no-in-array"
+			"ruleId": "jquery/no-in-array"
 		},
 		{
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 3,
 			"column": 2,
-			"ruleId": "@wikimedia/jquery/no-is-function"
+			"ruleId": "jquery/no-is-function"
 		},
 		{
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 3,
 			"column": 2,
-			"ruleId": "@wikimedia/jquery/no-map-util"
+			"ruleId": "jquery/no-map-util"
 		},
 		{
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 3,
 			"column": 2,
-			"ruleId": "@wikimedia/jquery/no-proxy"
+			"ruleId": "jquery/no-proxy"
 		},
 		{
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 3,
 			"column": 2,
-			"ruleId": "@wikimedia/jquery/no-trim"
+			"ruleId": "jquery/no-trim"
 		}
 	]
 ]

--- a/test/fixtures/jquery/invalid.js
+++ b/test/fixtures/jquery/invalid.js
@@ -2,25 +2,25 @@
 
 ( function () {
 
-	// eslint-disable-next-line @wikimedia/jquery/no-each-util
+	// eslint-disable-next-line jquery/no-each-util
 	$.each( [], function () {} );
 
-	// eslint-disable-next-line @wikimedia/jquery/no-grep
+	// eslint-disable-next-line jquery/no-grep
 	$.grep( [ 1, 2, 3 ], function () {} );
 
-	// eslint-disable-next-line @wikimedia/jquery/no-in-array
+	// eslint-disable-next-line jquery/no-in-array
 	$.inArray( 1, [ 1 ] );
 
-	// eslint-disable-next-line @wikimedia/jquery/no-is-function
+	// eslint-disable-next-line jquery/no-is-function
 	$.isFunction( function () {} );
 
-	// eslint-disable-next-line @wikimedia/jquery/no-map-util
+	// eslint-disable-next-line jquery/no-map-util
 	$.map( [ 1 ], function () {} );
 
-	// eslint-disable-next-line @wikimedia/jquery/no-proxy
+	// eslint-disable-next-line jquery/no-proxy
 	$.proxy( function () {}, this );
 
-	// eslint-disable-next-line @wikimedia/jquery/no-trim
+	// eslint-disable-next-line jquery/no-trim
 	$.trim( ' foo ' );
 
 }() );


### PR DESCRIPTION
Ideally we would install via the scoped NPM package,
but this results in giving all the rules an @wikimedia
prefix.