### PR TITLE
Add jquery/no-bind to jquery rules

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -4,6 +4,7 @@
   },
   "plugins": [ "jquery" ],
   "rules": {
+    "jquery/no-bind": "error",
     "jquery/no-each-util": "error",
     "jquery/no-grep": "error",
     "jquery/no-in-array": "error",

--- a/test/fixtures/jquery/invalid-results.json
+++ b/test/fixtures/jquery/invalid-results.json
@@ -4,6 +4,12 @@
 			"filename": "fixtures/jquery/invalid.js",
 			"line": 6,
 			"column": 2,
+			"ruleId": "jquery/no-bind"
+		},
+		{
+			"filename": "fixtures/jquery/invalid.js",
+			"line": 3,
+			"column": 2,
 			"ruleId": "jquery/no-each-util"
 		},
 		{

--- a/test/fixtures/jquery/invalid.js
+++ b/test/fixtures/jquery/invalid.js
@@ -2,6 +2,9 @@
 
 ( function () {
 
+	// eslint-disable-next-line jquery/no-bind
+	$( [] ).bind( 'click', function () {} );
+
 	// eslint-disable-next-line jquery/no-each-util
 	$.each( [], function () {} );
 


### PR DESCRIPTION
'bind' was deprecated in favour of 'on' in 3.0