### PR TITLE
Fix invalid rules

### DIFF
--- a/client.json
+++ b/client.json
@@ -8,6 +8,7 @@
   },
   "rules": {
     "no-alert": "error",
-    "no-console": "error"
+    "no-console": "error",
+    "no-implied-eval": "error"
   }
 }

--- a/common.json
+++ b/common.json
@@ -46,7 +46,6 @@
     "no-floating-decimal": "error",
     "no-implicit-coercion": [ "error", { "string": true, "boolean": false, "number": false } ],
     "no-implicit-globals": "error",
-    "no-implied-eval": "error",
     "no-label-var": "error",
     "no-loop-func": "error",
     "no-multi-spaces": "error",

--- a/test/fixtures/client/invalid-results.json
+++ b/test/fixtures/client/invalid-results.json
@@ -11,6 +11,12 @@
 			"line": 3,
 			"column": 2,
 			"ruleId": "no-console"
+		},
+		{
+			"filename": "fixtures/client/invalid.js",
+			"line": 3,
+			"column": 2,
+			"ruleId": "no-implied-eval"
 		}
 	]
 ]

--- a/test/fixtures/client/invalid.js
+++ b/test/fixtures/client/invalid.js
@@ -8,4 +8,7 @@
 	// eslint-disable-next-line no-console
 	console.log( name );
 
+	// eslint-disable-next-line no-implied-eval
+	setTimeout( name + '();' );
+
 }() );

--- a/test/fixtures/common/invalid-results.json
+++ b/test/fixtures/common/invalid-results.json
@@ -57,6 +57,12 @@
 		{
 			"filename": "fixtures/common/invalid.js",
 			"line": 4,
+			"column": 15,
+			"ruleId": "no-empty"
+		},
+		{
+			"filename": "fixtures/common/invalid.js",
+			"line": 4,
 			"column": 10,
 			"ruleId": "no-bitwise"
 		},
@@ -68,7 +74,7 @@
 		},
 		{
 			"filename": "fixtures/common/invalid.js",
-			"line": 17,
+			"line": 15,
 			"column": 4,
 			"ruleId": "semi-style"
 		},
@@ -76,13 +82,13 @@
 			"filename": "fixtures/common/invalid.js",
 			"line": 3,
 			"column": 4,
-			"ruleId": "no-inner-declarations"
+			"ruleId": "no-loop-func"
 		},
 		{
 			"filename": "fixtures/common/invalid.js",
 			"line": 0,
 			"column": 4,
-			"ruleId": "no-loop-func"
+			"ruleId": "no-inner-declarations"
 		},
 		{
 			"filename": "fixtures/common/invalid.js",
@@ -176,7 +182,13 @@
 		},
 		{
 			"filename": "fixtures/common/invalid.js",
-			"line": 7,
+			"line": 4,
+			"column": 26,
+			"ruleId": "no-trailing-spaces"
+		},
+		{
+			"filename": "fixtures/common/invalid.js",
+			"line": 3,
 			"column": 3,
 			"ruleId": "no-underscore-dangle"
 		},

--- a/test/fixtures/common/invalid.js
+++ b/test/fixtures/common/invalid.js
@@ -20,7 +20,7 @@ var APP;
 		// eslint-disable-next-line no-constant-condition
 		if ( true || options.quux ) {
 			name += options.quux;
-		// eslint-disable-next-line no-empty, dot-notation
+		// eslint-disable-next-line dot-notation
 		} else if ( options[ 'default' ] ) {
 		// eslint-disable-next-line no-unsafe-negation
 		} else if ( !'default' in options ) {
@@ -28,12 +28,14 @@ var APP;
 			name += named();
 		}
 
+		// eslint-disable-next-line no-empty
+		if ( name ) {
+		}
+
 		// eslint-disable-next-line no-bitwise
 		if ( ( bar | options.quux ) ) {
 			// eslint-disable-next-line no-eval
 			eval( '(' + name + ')' );
-			// eslint-disable-next-line no-implied-eval
-			this.setTimeout( name + '();' );
 			return;
 		}
 
@@ -89,7 +91,7 @@ var APP;
 		}
 
 		// eslint-disable-next-line no-trailing-spaces
-		options.spaces = 'foo';
+		options.spaces = 'foo';  
 
 		// eslint-disable-next-line no-underscore-dangle
 		options.lo_ = 'dash';


### PR DESCRIPTION
* Move no-implied-eval from common to client as
  setTimeout( 'string' ) is only available in browsers.
* Fix trigger for no-empty
* Fix trigger for no-trailing-spaces