### PR TITLE
common: Drop quote-props ES3-keyword restriction

### DIFF
--- a/common.json
+++ b/common.json
@@ -81,7 +81,7 @@
     "one-var": [ "error", "always" ],
     "operator-linebreak": [ "error", "after" ],
     "prefer-numeric-literals": "error",
-    "quote-props": [ "error", "as-needed", { "keywords": true } ],
+    "quote-props": [ "error", "as-needed" ],
     "quotes": [ "error", "single", { "avoidEscape": true } ],
     "semi": [ "error", "always" ],
     "semi-spacing": [ "error", { "before": false, "after": true } ],

--- a/test/fixtures/common/invalid.js
+++ b/test/fixtures/common/invalid.js
@@ -174,6 +174,11 @@ var APP;
 	// eslint-disable-next-line no-implicit-globals, no-global-assign
 	Date = APP.Date;
 
+	APP.example = {
+		// eslint-disable-next-line quote-props
+		'default': 'Legacy'
+	};
+
 	// eslint-disable-next-line no-multi-spaces
 	APP.defaults =  {
 		// eslint-disable-next-line no-floating-decimal

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -199,7 +199,8 @@
 		// Rule: quote-props
 		// Rule: quotes
 		first: 'Who',
-		'default': 'Legacy',
+		default: 'is',
+		null: 'there?',
 		// Rule: object-curly-spacing
 		second: { value: { of: 'What' } },
 		third: {


### PR DESCRIPTION
The "as-needed" option automatically takes into account whether
things like ES5 or ES6 are active. This is great.

However, the second option "{ keywords: true }" was effectively
forcing that behaviour to act as for ES**3.** That is, it didn't
support keywords as literal keys.