### PR TITLE
Apply no-buffer-constructor rule to node.

### DIFF
--- a/node.json
+++ b/node.json
@@ -1,5 +1,8 @@
 {
   "env": {
     "node": true
+  },
+  "rules": {
+    "no-buffer-constructor": "error"
   }
 }

--- a/test/fixtures/server/invalid.js
+++ b/test/fixtures/server/invalid.js
@@ -13,8 +13,8 @@
 	// eslint-disable-next-line no-misleading-character-class
 	/^[👍]$/.test( '👍' );
 
-	// eslint-disable-next-line prefer-const
-	let b = 1;
+	// eslint-disable-next-line prefer-const, no-buffer-constructor
+	let b = new Buffer( 1 );
 	const f = ( p ) => p;
 	f( b );
 }( this ) );


### PR DESCRIPTION
The buffer constructor is deprecated in Node.js and is causing
a warning in Node 10. As we're switching more services to node 10,
we need to lint for buffer constructors in the codebase.