### PR TITLE
Enable no-jquery/no-sizzle rule

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -22,6 +22,7 @@
     "no-jquery/no-now": "error",
     "no-jquery/no-parse-html-literal": "error",
     "no-jquery/no-proxy": "error",
+    "no-jquery/no-sizzle": "error",
     "no-jquery/no-slide": "error",
     "no-jquery/no-trim": "error",
     "no-jquery/no-type": "error"

--- a/test/fixtures/jquery/invalid.js
+++ b/test/fixtures/jquery/invalid.js
@@ -1,4 +1,6 @@
 ( function () {
+	var $div;
+
 	function f() {}
 
 	// eslint-disable-next-line no-jquery/no-and-self
@@ -91,8 +93,8 @@
 	// eslint-disable-next-line no-jquery/no-slide
 	$( [] ).slideDown();
 
-	// eslint-disable-next-line no-jquery/no-size
-	$( [] ).size();
+	// eslint-disable-next-line no-jquery/no-sizzle
+	$div.find( 'input:checkbox' );
 
 	// eslint-disable-next-line no-jquery/no-trim
 	$.trim( ' foo ' );


### PR DESCRIPTION
Fixes #174

Remove no-jquery/no-size test as it is now part of deprecated-1.8