### PR TITLE
Fix no-restricted-properties/syntax inheritance

### DIFF
--- a/language/.eslintrc.json
+++ b/language/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../server.json"
+}

--- a/language/es2016.json
+++ b/language/es2016.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "./rules-es2016.json",
-    "./not-es2016.json"
+    "./not-es2016.js"
   ],
   "parserOptions": {
     "ecmaVersion": 2016

--- a/language/es2017.json
+++ b/language/es2017.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "./rules-es2017.json",
-    "./not-es2017.json"
+    "./not-es2017.js"
   ],
   "parserOptions": {
     "ecmaVersion": 2017

--- a/language/es5.json
+++ b/language/es5.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "./rules-es5.json",
-    "./not-es5.json"
+    "./not-es5.js"
   ],
   "parserOptions": {
     "ecmaVersion": 5

--- a/language/es6.json
+++ b/language/es6.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "./rules-es6.json",
-    "./not-es6.json"
+    "./not-es6.js"
   ],
   "parserOptions": {
     "ecmaVersion": 6

--- a/language/merge.js
+++ b/language/merge.js
@@ -1,0 +1,20 @@
+module.exports = function ( childRules, parentRules ) {
+	// Start off with a standard merge
+	const mergedRules = Object.assign( {}, parentRules, childRules );
+
+	// For the specified keys, concatenate the lists
+	[ 'no-restricted-syntax', 'no-restricted-properties' ].forEach( function ( key ) {
+		// If either is unset, return the other
+		if ( !parentRules.rules[ key ] ) {
+			mergedRules.rules[ key ] = childRules.rules[ key ];
+		} else if ( !childRules.rules[ key ] ) {
+			mergedRules.rules[ key ] = parentRules.rules[ key ];
+		} else {
+			// If both are set, merge. Use the 0th value from parentRules arbitrarily,
+			// but it is assumed it is "error" for both.
+			mergedRules.rules[ key ] = ( parentRules.rules[ key ] || [] )
+				.concat( ( childRules.rules[ key ] || [] ).slice( 1 ) );
+		}
+	} );
+	return mergedRules;
+};

--- a/language/not-es2016.js
+++ b/language/not-es2016.js
@@ -1,5 +1,6 @@
-{
-  "extends": "./not-es2017.json",
+/* eslint-disable quote-props, quotes, indent */
+const merge = require( './merge.js' );
+const rules = {
   "rules": {
     "no-restricted-properties": [
       "error",
@@ -28,4 +29,5 @@
       }
     ]
   }
-}
+};
+module.exports = merge( rules, require( './not-es2017.js' ) );

--- a/language/not-es2017.js
+++ b/language/not-es2017.js
@@ -1,4 +1,6 @@
-{
+/* eslint-disable quote-props, quotes, indent */
+// Nothing to merge with yet
+module.exports = {
   "rules": {
     "no-restricted-properties": [
       "error",
@@ -28,4 +30,4 @@
       }
     ]
   }
-}
+};

--- a/language/not-es5.js
+++ b/language/not-es5.js
@@ -1,5 +1,6 @@
-{
-  "extends": "./not-es6.json",
+/* eslint-disable quote-props, quotes, indent */
+const merge = require( './merge.js' );
+const rules = {
   "rules": {
     "no-restricted-properties": [
       "error",
@@ -95,4 +96,6 @@
       }
     ]
   }
-}
+};
+
+module.exports = merge( rules, require( './not-es6.js' ) );

--- a/language/not-es6.js
+++ b/language/not-es6.js
@@ -1,5 +1,6 @@
-{
-  "extends": "./not-es2016.json",
+/* eslint-disable quote-props, quotes, indent */
+const merge = require( './merge.js' );
+const rules = {
   "rules": {
     "no-restricted-syntax": [
       "error",
@@ -9,4 +10,5 @@
       }
     ]
   }
-}
+};
+module.exports = merge( rules, require( './not-es2016.js' ) );

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
     "language/rules-es6.json",
     "language/rules-es2016.json",
     "language/rules-es2017.json",
-    "language/not-es5.json",
-    "language/not-es6.json",
-    "language/not-es2016.json",
-    "language/not-es2017.json",
+    "language/not-es5.js",
+    "language/not-es6.js",
+    "language/not-es2016.js",
+    "language/not-es2017.js",
+    "language/merge.js",
     "language/es2015.json"
   ],
   "contributors": [

--- a/test/fixtures/client/invalid.js
+++ b/test/fixtures/client/invalid.js
@@ -11,4 +11,22 @@
 	// eslint-disable-next-line no-implied-eval
 	setTimeout( name + '();' );
 
+	// not-es5
+	// eslint-disable-next-line no-restricted-properties
+	''.codePointAt();
+	// eslint-disable-next-line no-restricted-syntax
+	[].keys();
+
+	// not-es6
+	// eslint-disable-next-line no-restricted-syntax
+	[].includes();
+
+	// not-es2016
+	// eslint-disable-next-line no-restricted-properties
+	''.padStart();
+
+	// not-es2017
+	// eslint-disable-next-line no-restricted-properties
+	''.trimEnd();
+
 }() );

--- a/test/fixtures/server/invalid.js
+++ b/test/fixtures/server/invalid.js
@@ -26,4 +26,17 @@
 
 	// eslint-disable-next-line template-curly-spacing, no-unused-expressions
 	`${ global.foo }`;
+
+	// not-es6
+	// eslint-disable-next-line no-restricted-syntax
+	[].includes();
+
+	// not-es2016
+	// eslint-disable-next-line no-restricted-properties
+	''.padStart();
+
+	// not-es2017
+	// eslint-disable-next-line no-restricted-properties
+	''.trimEnd();
+
 }( this ) );


### PR DESCRIPTION
This was never working before as eslint can't merge these rule definitions.

Add a few language tests to client/server to assert this works.