### PR TITLE
Fix language rule merge when key is unset in both rulesets

### DIFF
--- a/language/merge.js
+++ b/language/merge.js
@@ -1,10 +1,13 @@
 module.exports = function ( childRules, parentRules ) {
-	// Start off with a standard merge
-	const mergedRules = Object.assign( {}, parentRules, childRules );
+	// Only rules are preserved
+	const mergedRules = { rules: {} };
+
+	// Merge rules
+	Object.assign( mergedRules.rules, parentRules.rules, childRules.rules );
 
 	// For the specified keys, concatenate the lists
 	[ 'no-restricted-syntax', 'no-restricted-properties' ].forEach( function ( key ) {
-		if ( !mergedRules[ key ] ) {
+		if ( !mergedRules.rules[ key ] ) {
 			// If both are unset, do nothing
 			return;
 		} else if ( !parentRules.rules[ key ] ) {
@@ -13,9 +16,9 @@ module.exports = function ( childRules, parentRules ) {
 		} else if ( !childRules.rules[ key ] ) {
 			mergedRules.rules[ key ] = parentRules.rules[ key ];
 		} else {
-			// If both are set, merge. Use the 0th value from parentRules arbitrarily,
-			// but it is assumed it is "error" for both.
-			mergedRules.rules[ key ] = ( parentRules.rules[ key ] || [] )
+			// If both are set, merge. Assume mode is 'error'.
+			mergedRules.rules[ key ] = [ 'error' ]
+				.concat( ( parentRules.rules[ key ] || [] ).slice( 1 ) )
 				.concat( ( childRules.rules[ key ] || [] ).slice( 1 ) );
 		}
 	} );

--- a/language/merge.js
+++ b/language/merge.js
@@ -4,8 +4,11 @@ module.exports = function ( childRules, parentRules ) {
 
 	// For the specified keys, concatenate the lists
 	[ 'no-restricted-syntax', 'no-restricted-properties' ].forEach( function ( key ) {
-		// If either is unset, return the other
-		if ( !parentRules.rules[ key ] ) {
+		if ( !mergedRules[ key ] ) {
+			// If both are unset, do nothing
+			return;
+		} else if ( !parentRules.rules[ key ] ) {
+			// If either is unset, return the other
 			mergedRules.rules[ key ] = childRules.rules[ key ];
 		} else if ( !childRules.rules[ key ] ) {
 			mergedRules.rules[ key ] = parentRules.rules[ key ];

--- a/language/merge.js
+++ b/language/merge.js
@@ -10,13 +10,8 @@ module.exports = function ( childRules, parentRules ) {
 		if ( !mergedRules.rules[ key ] ) {
 			// If both are unset, do nothing
 			return;
-		} else if ( !parentRules.rules[ key ] ) {
-			// If either is unset, return the other
-			mergedRules.rules[ key ] = childRules.rules[ key ];
-		} else if ( !childRules.rules[ key ] ) {
-			mergedRules.rules[ key ] = parentRules.rules[ key ];
 		} else {
-			// If both are set, merge. Assume mode is 'error'.
+			// Assume mode is 'error'.
 			mergedRules.rules[ key ] = [ 'error' ]
 				.concat( ( parentRules.rules[ key ] || [] ).slice( 1 ) )
 				.concat( ( childRules.rules[ key ] || [] ).slice( 1 ) );


### PR DESCRIPTION
This fixes not-es2016.js where this occurs.