### PR TITLE
Enable no-jquery/no-constructor-attributes

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -8,6 +8,7 @@
     "no-jquery/no-animate": [ "error", { "allowScroll": true } ],
     "no-jquery/no-animate-toggle": "error",
     "no-jquery/no-class-state": "error",
+    "no-jquery/no-constructor-attributes": "error",
     "no-jquery/no-each-util": "error",
     "no-jquery/no-error": "error",
     "no-jquery/no-fade": "error",

--- a/test/fixtures/jquery/invalid.js
+++ b/test/fixtures/jquery/invalid.js
@@ -21,6 +21,9 @@
 	// eslint-disable-next-line no-jquery/no-class-state
 	$( [] ).hasClass();
 
+	// eslint-disable-next-line no-jquery/no-constructor-attributes
+	$( '<div>', { id: 'foo' } );
+
 	// eslint-disable-next-line no-jquery/no-delegate
 	$( [] ).delegate( 'click', function () {} );
 


### PR DESCRIPTION
See wikimedia/eslint-plugin-no-jquery#86 for rationale.