### PR TITLE
Add rules for .vue files

### DIFF
--- a/mediawiki-vue.json
+++ b/mediawiki-vue.json
@@ -1,0 +1,11 @@
+{
+	"extends": [
+		"./vue-es5.js"
+	],
+	"rules": {
+		"no-implicit-globals": "off",
+		"vue/v-bind-style": [ "error", "longform" ],
+		"vue/v-slot-style": [ "error", "longform" ],
+		"vue/v-on-style": [ "error", "longform" ]
+	}
+}

--- a/mediawiki.json
+++ b/mediawiki.json
@@ -8,5 +8,4 @@
     "mediawiki/msg-doc": "error",
     "mediawiki/valid-package-file-require": "error"
   }
-  ]
 }

--- a/mediawiki.json
+++ b/mediawiki.json
@@ -7,5 +7,11 @@
   "rules": {
     "mediawiki/msg-doc": "error",
     "mediawiki/valid-package-file-require": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": "**/*.vue",
+      "extends": "./mediawiki-vue.json"
+    }
+  ]
 }

--- a/mediawiki.json
+++ b/mediawiki.json
@@ -7,11 +7,6 @@
   "rules": {
     "mediawiki/msg-doc": "error",
     "mediawiki/valid-package-file-require": "error"
-  },
-  "overrides": [
-    {
-      "files": "**/*.vue",
-      "extends": "./mediawiki-vue.json"
-    }
+  }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,30 @@
         "v8-compile-cache": "^2.0.3"
       }
     },
+    "eslint-plugin-es": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
+      "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+        }
+      }
+    },
     "eslint-plugin-json": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-2.1.1.tgz",
@@ -325,6 +349,23 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-4.0.0.tgz",
       "integrity": "sha512-+0i2xcYryUoLawi47Lp0iJKzkP931G5GXwIOq1KBKQc2pknV1VPjfE6b4mI2mR2RnL7WRoS30YjwC9SjQgJDXQ=="
+    },
+    "eslint-plugin-vue": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
+      "integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+      "requires": {
+        "natural-compare": "^1.4.0",
+        "semver": "^5.6.0",
+        "vue-eslint-parser": "^7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
     },
     "eslint-scope": {
       "version": "5.0.0",
@@ -1066,6 +1107,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.1.tgz",
       "integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A=="
+    },
+    "vue-eslint-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz",
+      "integrity": "sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==",
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.15"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint config following Wikimedia code conventions.",
   "main": "common.json",
   "scripts": {
-    "test": "eslint . --ext .js,.json && node test/test.js",
+    "test": "eslint . --ext .js,.json,.vue && node test/test.js",
     "build-invalid": "node test/test.js dump"
   },
   "repository": {
@@ -25,8 +25,13 @@
     "node.json",
     "jquery.json",
     "mediawiki.json",
+    "mediawiki-vue.json",
     "qunit.json",
     "server.json",
+    "vue-common.json",
+    "vue-es5.js",
+    "vue-es6.js",
+    "vue-wrappers.js",
     "language/es5.json",
     "language/rules-es5.json",
     "language/not-es5.js",
@@ -57,10 +62,12 @@
   "license": "MIT",
   "dependencies": {
     "eslint": "^6.8.0",
+    "eslint-plugin-es": "^3.0.0",
     "eslint-plugin-json": "^2.1.1",
     "eslint-plugin-mediawiki": "^0.2.1",
     "eslint-plugin-no-jquery": "^2.3.2",
-    "eslint-plugin-qunit": "^4.0.0"
+    "eslint-plugin-qunit": "^4.0.0",
+    "eslint-plugin-vue": "^6.1.2"
   },
   "devDependencies": {
     "assert-diff": "^2.0.3"

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install --save-dev eslint-config-wikimedia
 Then, [configure ESLint](https://eslint.org/docs/user-guide/configuring) with one or more `.eslintrc.json` files as appropriate.
 
 ## Example configurations
-Bellow are some potential recommended uses:
+Below are some potential recommended uses:
 
 ### A typical front-end project
 This profile allows ES5 code and browser native functions. It will complain about ES6+ code and language features.
@@ -36,13 +36,30 @@ This profile adds the jQuery `$` global, and additional rules preventing the use
 ```
 
 #### MediaWiki
-Code that runs in MediaWiki can use this profile. It enforces rules that are specific to the MediaWiki codebase (core and extensions), such as correct documentation of `mw.message` usage.
+Code that runs in MediaWiki can use this profile. It enforces rules that are specific to the MediaWiki codebase (core and extensions), such as correct documentation of `mw.message` usage. It also automatically applies the Vue plugin and Vue-specific rules to `.vue` files, including MediaWiki-specific Vue rules such as prohibiting ES6 syntax and prohibiting shorthand syntax for `v-bind`, `v-on` and `v-slot`.
 `.eslintrc.json`:
 ```json
 {
 	"extends": [
 		"wikimedia/client",
 		"wikimedia/mediawiki"
+	]
+}
+```
+
+#### .vue files
+The MediaWiki profile automatically applies the Vue plugin to `.vue` files, and enforces MediaWiki-specific Vue rules. For code outside MediaWiki, or for `.vue` files that don't use ResourceLoader, you can use the `wikimedia/vue-es5` or `wikimedia/vue-es6` profile. These profiles only enforce non-MediaWiki-specific rules for Vue code.
+`.eslintrc.json`:
+```json
+{
+	"extends": [
+		"wikimedia/client"
+	],
+	"overrides": [
+		{
+			"files": "**/*.vue",
+			"extends": "wikimedia/vue-es5"
+		}
 	]
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ This profile adds the jQuery `$` global, and additional rules preventing the use
 ```
 
 #### MediaWiki
-Code that runs in MediaWiki can use this profile. It enforces rules that are specific to the MediaWiki codebase (core and extensions), such as correct documentation of `mw.message` usage. It also automatically applies the Vue plugin and Vue-specific rules to `.vue` files, including MediaWiki-specific Vue rules such as prohibiting ES6 syntax and prohibiting shorthand syntax for `v-bind`, `v-on` and `v-slot`.
+Code that runs in MediaWiki can use this profile. It enforces rules that are specific to the MediaWiki codebase (core and extensions), such as correct documentation of `mw.message` usage.
 `.eslintrc.json`:
 ```json
 {
@@ -48,17 +48,19 @@ Code that runs in MediaWiki can use this profile. It enforces rules that are spe
 ```
 
 #### .vue files
-The MediaWiki profile automatically applies the Vue plugin to `.vue` files, and enforces MediaWiki-specific Vue rules. For code outside MediaWiki, or for `.vue` files that don't use ResourceLoader, you can use the `wikimedia/vue-es5` or `wikimedia/vue-es6` profile. These profiles only enforce non-MediaWiki-specific rules for Vue code.
+The `mediawiki-vue` profile enforces common conventions for Vue code, as well as MediaWiki-specific Vue rules like requiring ES5 and prohibiting shorthands for `v-bind`, `v-on` and `v-slot`. For code outside MediaWiki, you can use the `vue-es5` or `vue-es6` profiles.
+Typically, you will want to apply these profiles only to `.vue` files, as follows:
 `.eslintrc.json`:
 ```json
 {
 	"extends": [
-		"wikimedia/client"
+		"wikimedia/client",
+		"wikimedia/mediawiki"
 	],
 	"overrides": [
 		{
 			"files": "**/*.vue",
-			"extends": "wikimedia/vue-es5"
+			"extends": "wikimedia/mediawiki-vue"
 		}
 	]
 }

--- a/test/fixtures/mediawiki-vue/.eslintrc.json
+++ b/test/fixtures/mediawiki-vue/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"root": true,
+	"extends": "../../../mediawiki-vue.json",
+	"globals": {
+		"module": "readonly"
+	}
+}

--- a/test/fixtures/mediawiki-vue/invalid.vue
+++ b/test/fixtures/mediawiki-vue/invalid.vue
@@ -1,0 +1,24 @@
+<template>
+	<div>
+		<!-- eslint-disable-next-line vue/v-bind-style -->
+		<a :href="foo">Foo</a>
+		<!-- eslint-disable-next-line vue/v-on-style -->
+		<a @click="onClick">Click me</a>
+		<blah-component>
+			<!-- eslint-disable-next-line vue/v-slot-style -->
+			<template #default>
+				foo
+			</template>
+			<!-- eslint-disable-next-line vue/v-slot-style -->
+			<template #bar>
+				bar
+			</template>
+		</blah-component>
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+};
+</script>

--- a/test/fixtures/mediawiki-vue/positiveFailures.json
+++ b/test/fixtures/mediawiki-vue/positiveFailures.json
@@ -1,0 +1,5 @@
+[
+	"vue/v-bind-style",
+	"vue/v-on-style",
+	"vue/v-slot-style"
+]

--- a/test/fixtures/mediawiki-vue/valid.vue
+++ b/test/fixtures/mediawiki-vue/valid.vue
@@ -1,0 +1,28 @@
+<template>
+	<div>
+		<!-- Rule: vue/v-bind-style -->
+		<a v-bind:href="foo">Foo</a>
+		<!-- Rule: vue/v-on-style -->
+		<a v-on:click="onClick">Click me</a>
+		<blah-component>
+			<!-- Rule: vue/v-slot-style -->
+			<template v-slot:default>
+				foo
+			</template>
+			<template v-slot:bar>
+				bar
+			</template>
+		</blah-component>
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+
+};
+</script>
+
+<style>
+
+</style>

--- a/test/fixtures/vue-common/.eslintrc.json
+++ b/test/fixtures/vue-common/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"root": true,
+	"extends": "../../../vue-common.json",
+	"globals": {
+		"module": "readonly"
+	}
+}

--- a/test/fixtures/vue-common/invalid.vue
+++ b/test/fixtures/vue-common/invalid.vue
@@ -1,0 +1,44 @@
+<template>
+	<div>
+		<blah-component>
+			<!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -->
+			<template slot="foo">
+				foo
+			</template>
+			<!-- eslint-disable-next-line vue/no-deprecated-scope-attribute -->
+			<template v-slot:name="bar" scope="baz">
+				{{ baz }}
+			</template>
+			<!-- eslint-disable-next-line vue/no-deprecated-slot-scope-attribute -->
+			<template v-slot:name="bar" slot-scope="baz">
+				{{ baz }}
+			</template>
+		</blah-component>
+		<!-- eslint-disable-next-line vue/no-static-inline-styles -->
+		<span style="color: red">Red</span>
+		<!-- eslint-disable-next-line vue/v-on-function-call -->
+		<a @click="foo()">Click me</a>
+		<!-- eslint-disable-next-line vue/no-unsupported-features -->
+		<!-- Can't actually be covered, since it doesn't do anything (yet) when set to v2.6 -->
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+	// eslint-disable-next-line vue/no-reserved-component-names, vue/name-property-casing
+	name: 'div',
+	props: {
+		foo: {
+			type: Boolean,
+			// eslint-disable-next-line vue/no-boolean-default
+			default: false
+		}
+	},
+	// eslint-disable-next-line vue/order-in-components
+	components: {
+		// eslint-disable-next-line vue/no-reserved-component-names, vue/no-unused-components
+		button: {}
+	}
+};
+</script>

--- a/test/fixtures/vue-common/positiveFailures.json
+++ b/test/fixtures/vue-common/positiveFailures.json
@@ -1,0 +1,4 @@
+[
+	"vue/v-on-function-call",
+	"vue/order-in-components"
+]

--- a/test/fixtures/vue-common/valid.vue
+++ b/test/fixtures/vue-common/valid.vue
@@ -11,8 +11,6 @@
 			c="d"
 			e="f"
 		/>
-		<!-- Rule: vue/no-v-html -->
-		<span v-html="foo" />
 		<!-- Rule: vue/v-on-function-call -->
 		<a @click="foo">Click me</a>
 		<!-- Rule: vue/padding-line-between-blocks -->

--- a/test/fixtures/vue-common/valid.vue
+++ b/test/fixtures/vue-common/valid.vue
@@ -1,0 +1,71 @@
+<template>
+	<div x="y">
+		<!-- Rule: vue/component-tags-order -->
+		<!-- Rule: vue/html-indent -->
+		<!-- Rule: vue/html-closing-bracket-newline -->
+		<!-- Rule: vue/max-attributes-per-line -->
+		<!-- Rule: vue/html-self-closing -->
+		<span a="b" c="d" />
+		<span
+			a="b"
+			c="d"
+			e="f"
+		/>
+		<!-- Rule: vue/no-v-html -->
+		<span v-html="foo" />
+		<!-- Rule: vue/v-on-function-call -->
+		<a @click="foo">Click me</a>
+		<!-- Rule: vue/padding-line-between-blocks -->
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+	// Rule: vue/order-in-components
+	el: '',
+	name: '',
+	parent: null,
+	functional: false,
+	delimiters: [],
+	comments: [],
+	components: {},
+	directives: {},
+	filters: {},
+	extends: null,
+	mixins: [],
+	provide: {},
+	inject: {},
+	inheritAttrs: {},
+	model: '',
+	props: {},
+	propsData: {},
+	data: function () {
+		return {};
+	},
+	computed: {},
+	methods: {},
+	watch: {},
+	fetch: {},
+	beforeCreate: function () {},
+	created: function () {},
+	beforeMount: function () {},
+	mounted: function () {},
+	beforeUpdate: function () {},
+	updated: function () {},
+	activated: function () {},
+	deactivated: function () {},
+	beforeDestroy: function () {},
+	destroyed: function () {},
+	template: '',
+	render: function ( h ) {
+		return h( 'div' );
+	},
+	renderError: function () {}
+
+};
+</script>
+
+<style>
+
+</style>

--- a/test/fixtures/vue-es5/.eslintrc.json
+++ b/test/fixtures/vue-es5/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"root": true,
+	"extends": "../../../vue-es5.js",
+	"globals": {
+		"module": "readonly"
+	}
+}

--- a/test/fixtures/vue-es5/invalid.vue
+++ b/test/fixtures/vue-es5/invalid.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<!-- eslint-disable-next-line vue/no-restricted-syntax -->
+		<a @click="[].keys() ? 23 : 42" />
+		<!-- eslint-disable-next-line vue/no-restricted-syntax -->
+		<a @click="[].values() ? 23 : 42" />
+		<!-- eslint-disable-next-line vue/no-restricted-syntax -->
+		<a @click="[].find( function () {} )" />
+		<!-- eslint-disable-next-line vue/no-restricted-syntax -->
+		<a @click="''.includes( 'x' )" />
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+};
+</script>

--- a/test/fixtures/vue-es6/.eslintrc.json
+++ b/test/fixtures/vue-es6/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"root": true,
+	"extends": "../../../vue-es6.js",
+	"globals": {
+		"module": "readonly"
+	}
+}

--- a/test/fixtures/vue-es6/invalid.vue
+++ b/test/fixtures/vue-es6/invalid.vue
@@ -1,0 +1,12 @@
+<template>
+	<div>
+		<!-- eslint-disable-next-line vue/no-restricted-syntax -->
+		<a @click="[].includes( 'x' )" />
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+};
+</script>

--- a/test/fixtures/vue-es6/valid.vue
+++ b/test/fixtures/vue-es6/valid.vue
@@ -1,0 +1,14 @@
+<template>
+	<div>
+		<!-- Rule: vue/no-restricted-syntax -->
+		<a @click="[].keys() ? 23 : 42" />
+		<a @click="[].values() ? 23 : 42" />
+		<a @click="[].find( function () {} )" />
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+};
+</script>

--- a/test/fixtures/vue-wrappers/.eslintrc.json
+++ b/test/fixtures/vue-wrappers/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"root": true,
+	"extends": "../../../vue-common.json",
+	"globals": {
+		"module": "readonly"
+	}
+}

--- a/test/fixtures/vue-wrappers/invalid.vue
+++ b/test/fixtures/vue-wrappers/invalid.vue
@@ -1,0 +1,37 @@
+<template>
+	<div>
+		<!-- eslint-disable-next-line vue/array-bracket-spacing -->
+		<div :class="['foo', 'bar']" />
+		<!-- eslint-disable-next-line vue/key-spacing, vue/object-curly-spacing -->
+		<a :class="{foo:'bar'}" />
+		<!-- eslint-disable-next-line vue/eqeqeq -->
+		<a :class="foo == 4 ? 8 : 15" />
+		<!-- eslint-disable-next-line vue/dot-location -->
+		<a :href="foo.
+			bar" />
+		<!-- eslint-disable-next-line vue/block-spacing, vue/keyword-spacing -->
+		<a @click="if(foo){bar()}" />
+		<!-- eslint-disable vue/brace-style -->
+		<a @click="if ( foo )
+		{
+			bar()
+		}" />
+		<!-- eslint-disable-next-line vue/camelcase -->
+		<a @click="function foo_bar() { }" />
+		<!-- eslint-disable-next-line vue/space-infix-ops -->
+		<a :href="16+23" />
+		<!-- eslint-disable-next-line vue/space-unary-ops -->
+		<a :href="! x" />
+		<!-- eslint-disable-next-line vue/comma-dangle -->
+		<div :class="[ 'foo', 'bar', ]" />
+		<!-- eslint-disable-next-line vue/no-multi-spaces -->
+		<a :href="16  + 23" />
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+
+};
+</script>

--- a/test/fixtures/vue-wrappers/positiveFailures.json
+++ b/test/fixtures/vue-wrappers/positiveFailures.json
@@ -1,0 +1,14 @@
+[
+	"vue/array-bracket-spacing",
+	"vue/block-spacing",
+	"vue/brace-style",
+	"vue/camelcase",
+	"vue/comma-dangle",
+	"vue/dot-location",
+	"vue/eqeqeq",
+	"vue/key-spacing",
+	"vue/keyword/spacing",
+	"vue/object-curly-spacing",
+	"vue/space-infix-ops",
+	"vue/space-unary-ops"
+]

--- a/test/fixtures/vue-wrappers/valid.vue
+++ b/test/fixtures/vue-wrappers/valid.vue
@@ -1,0 +1,36 @@
+<template>
+	<div>
+		<!-- Rule: vue/array-bracket-spacing -->
+		<!-- Rule: vue/comma-dangle -->
+		<div :class="[ 'foo', 'bar' ]" />
+		<!-- Rule: vue/key-spacing -->
+		<!-- Rule: vue/object-curly-spacing -->
+		<a :class="{ foo: 'bar' }" />
+		<!-- Rule: vue/eqeqeq -->
+		<a :class="foo === 4 ? 8 : 15" />
+		<!-- Rule: vue/dot-location -->
+		<a :href="foo
+			.bar" />
+		<!-- Rule: vue/block-spacing -->
+		<!-- Rule: vue/keyword-spacing -->
+		<a @click="if ( foo ) { bar() }" />
+		<!-- Rule: vue/brace-style -->
+		<a @click="if ( foo ) {
+			bar()
+		}" />
+		<!-- Rule: vue/camelcase -->
+		<a @click="function fooBar() { }" />
+		<!-- Rule: vue/space-infix-ops -->
+		<a :href="16 + 23" />
+		<!-- Rule: vue/space-unary-ops -->
+		<a :href="typeof 42" />
+		<a :href="!x" />
+	</div>
+</template>
+
+<script>
+// @vue/component
+module.exports = {
+
+};
+</script>

--- a/vue-common.json
+++ b/vue-common.json
@@ -1,0 +1,60 @@
+{
+	"extends": [
+		"plugin:vue/recommended",
+		"./common.json",
+		"./vue-wrappers.js"
+	],
+	"rules": {
+		"vue/component-tags-order": [ "error", {
+			"order": [ "template", "script", "style" ]
+		} ],
+		"vue/html-indent": [ "error", "tab" ],
+		"vue/html-closing-bracket-newline": "off",
+		"vue/max-attributes-per-line": [ "warn", {
+			"singleline": 2,
+			"multiline": {
+				"max": 1,
+				"allowFirstLine": true
+			}
+		} ],
+		"vue/no-boolean-default": "error",
+		"vue/no-deprecated-scope-attribute": "error",
+		"vue/no-deprecated-slot-attribute": "error",
+		"vue/no-deprecated-slot-scope-attribute": "error",
+		"vue/no-reserved-component-names": "error",
+		"vue/no-static-inline-styles": "error",
+		"vue/no-unsupported-features": [ "error", {
+			"version": "2.6.11"
+		} ],
+		"vue/no-v-html": "off",
+		"vue/order-in-components": [ "error", {
+			"order": [
+				"el",
+				"name",
+				"parent",
+				"functional",
+				[ "delimiters", "comments" ],
+				[ "components", "directives", "filters" ],
+				"extends",
+				"mixins",
+				"provide",
+				"inject",
+				"inheritAttrs",
+				"model",
+				[ "props", "propsData" ],
+				"asyncData",
+				"data",
+				"computed",
+				"methods",
+				"watch",
+				"fetch",
+				"LIFECYCLE_HOOKS",
+				"head",
+				[ "template", "render" ],
+				"renderError"
+			]
+		} ],
+		"vue/padding-line-between-blocks": [ "error", "always" ],
+		"vue/v-on-function-call": "error"
+	}
+}

--- a/vue-common.json
+++ b/vue-common.json
@@ -26,7 +26,6 @@
 		"vue/no-unsupported-features": [ "error", {
 			"version": "2.6.11"
 		} ],
-		"vue/no-v-html": "off",
 		"vue/order-in-components": [ "error", {
 			"order": [
 				"el",

--- a/vue-es5.js
+++ b/vue-es5.js
@@ -1,0 +1,25 @@
+/* eslint-disable quotes, quote-props  */
+module.exports = {
+	"extends": [
+		"./vue-es6.js",
+		// We can't use ./language/es5.js here, because ecmaVersion: 5 breaks the Vue plugin
+		// Instead, use es/no-2015 to prohibit ES6+ syntax
+		"./language/not-es5.js",
+		"plugin:es/no-2015"
+	],
+	"plugins": [ "es" ],
+	// The Vue plugin sets sourceType: "module" and enables JSX: undo those things
+	"parserOptions": {
+		"sourceType": "script",
+		"ecmaFeatures": {
+			"jsx": false
+		}
+	},
+	"env": {
+		"es6": false
+	},
+	"rules": {
+		// This is a wrapper rule, but it can't be in vue-wrappers.js because it's ES5-specific
+		"vue/no-restricted-syntax": require( './language/not-es5.js' ).rules[ 'no-restricted-syntax' ]
+	}
+};

--- a/vue-es6.js
+++ b/vue-es6.js
@@ -1,0 +1,11 @@
+/* eslint-disable quote-props, quotes */
+module.exports = {
+	"extends": [
+		"./vue-common.json",
+		"./language/es6.json"
+	],
+	"rules": {
+		// This is a wrapper rule, but it can't be in vue-wrappers.js because it's ES6-specific
+		"vue/no-restricted-syntax": require( './language/not-es6.js' ).rules[ 'no-restricted-syntax' ]
+	}
+};

--- a/vue-wrappers.js
+++ b/vue-wrappers.js
@@ -1,0 +1,38 @@
+/*
+ * eslint-plugin-vue doesn't automatically apply core eslint rules to JS code inside templates,
+ * but it does provide wrappers for some rules (e.g. vue/eqeqeq applies the eqeqeq rule in
+ * templates). Set the values for these wrapped rules to be equal to the corresponding values
+ * in common.json
+ */
+const commonRules = require( './common.json' ).rules;
+const rulesToMap = [
+	'array-bracket-spacing',
+	'arrow-spacing',
+	'block-spacing',
+	'brace-style',
+	'camelcase',
+	'comma-dangle',
+	'dot-location',
+	'eqeqeq',
+	'key-spacing',
+	'keyword-spacing',
+	'no-empty-pattern',
+	'no-irregular-whitespace',
+	'no-multi-spaces',
+	// no-restricted-syntax differs between ES5/ES6, so it's set in vue-es5.js / vue-es6.js
+	'object-curly-spacing',
+	'sort-keys',
+	'space-infix-ops',
+	'space-unary-ops'
+];
+
+const wrappedRules = {};
+for ( const rule of rulesToMap ) {
+	if ( rule in commonRules ) {
+		wrappedRules[ 'vue/' + rule ] = commonRules[ rule ];
+	}
+}
+
+module.exports = {
+	rules: wrappedRules
+};


### PR DESCRIPTION
Use the vue plugin for linting .vue files, and the es plugin to work
around the vue plugin's inability to support ES5-only environments.

Note that the Vue plugin does not report unused disable directives in
HTML templates, so the invalid.vue test files don't fully work. This
requires an upstream fix.

vue-common: Most Vue rules
vue-es6: ES6-specific Vue rules
vue-es5: ES5-specific Vue rules
vue-wrappers: Generate values for Vue rules that wrap core eslint
              rules (e.g. vue/eqeqeq)