### PR TITLE
build: Upgrade assert-diff from 2.0.3 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,13 +90,13 @@
       }
     },
     "assert-diff": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/assert-diff/-/assert-diff-2.0.3.tgz",
-      "integrity": "sha512-TAPT9BmNP3384kP9jdkgRIYdddSO2hG3oG8B5+hoTd2khGC0XrM8ZT+FEkTr4kFFhzDuUveGtvNGcXD63qP6Mw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/assert-diff/-/assert-diff-3.0.0.tgz",
+      "integrity": "sha512-BseRFluNIrvKiTOXt2zsW0pwJ+XQGCMNDr6rKRQdnVDe5Rq2tISYYxtqn1FlxsYy+kj/oPJYECzAfk6liI3v6w==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
-        "json-diff": "0.5.2"
+        "json-diff": "0.5.4"
       }
     },
     "assert-plus": {
@@ -660,9 +660,9 @@
       }
     },
     "json-diff": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.2.tgz",
-      "integrity": "sha512-N7oapTQdD4rLMUtA7d1HATCPY/BpHuSNL1mhvIuoS0u5NideDvyR+gB/ntXB7ejFz/LM0XzPLNUJQcC68n5sBw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.4.tgz",
+      "integrity": "sha512-q5Xmx9QXNOzOzIlMoYtLrLiu4Jl/Ce2bn0CNcv54PhyH89CI4GWlGVDye8ei2Ijt9R3U+vsWPsXpLUNob8bs8Q==",
       "dev": true,
       "requires": {
         "cli-color": "~0.1.6",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "eslint-plugin-qunit": "^4.0.0"
   },
   "devDependencies": {
-    "assert-diff": "^2.0.3"
+    "assert-diff": "^3.0.0"
   }
 }


### PR DESCRIPTION
No actual breaking changes in upstream AFAICT.