### PR TITLE
es6: New rule `no-constructor-return`

### DIFF
--- a/language/rules-es6.json
+++ b/language/rules-es6.json
@@ -3,6 +3,7 @@
 	"rules": {
 		"arrow-parens": "error",
 		"default-param-last": "error",
+		"no-constructor-return": "error",
 		"no-misleading-character-class": "error",
 		"no-new-require": "error",
 		"no-useless-computed-key": "error",


### PR DESCRIPTION
Part of #204