### PR TITLE
Use 'es' plugin in language/ where possible

### DIFF
--- a/language/not-es2016.js
+++ b/language/not-es2016.js
@@ -1,7 +1,11 @@
 /* eslint-disable quote-props, quotes */
 const merge = require( './merge.js' );
 const rules = {
+	"plugins": [ "es" ],
 	"rules": {
+		"es/no-object-entries": "error",
+		"es/no-object-getownpropertydescriptors": "error",
+		"es/no-object-values": "error",
 		"no-restricted-properties": [
 			"error",
 			{
@@ -11,21 +15,6 @@ const rules = {
 			{
 				"property": "padStart",
 				"message": "Unsupported method String.prototype.padStart requires ES2017."
-			},
-			{
-				"object": "Object",
-				"property": "entries",
-				"message": "Unsupported method Object.entries requires ES2017."
-			},
-			{
-				"object": "Object",
-				"property": "getOwnPropertyDescriptors",
-				"message": "Unsupported method Object.getOwnPropertyDescriptors requires ES2017."
-			},
-			{
-				"object": "Object",
-				"property": "values",
-				"message": "Unsupported method Object.values requires ES2017."
 			}
 		]
 	}

--- a/language/not-es2018.js
+++ b/language/not-es2018.js
@@ -28,6 +28,7 @@ const rules = {
 				"property": "flatMap",
 				"message": "Unsupported method Array.prototype.flatMap requires ES2019."
 			},
+			// https://github.com/mysticatea/eslint-plugin-es/issues/25
 			{
 				"object": "Object",
 				"property": "fromEntries",

--- a/language/not-es5.js
+++ b/language/not-es5.js
@@ -1,7 +1,41 @@
 /* eslint-disable quote-props, quotes */
 const merge = require( './merge.js' );
 const rules = {
+	"plugins": [ "es" ],
 	"rules": {
+		"es/no-array-from": "error",
+		"es/no-array-of": "error",
+		"es/no-math-acosh": "error",
+		"es/no-math-asinh": "error",
+		"es/no-math-atanh": "error",
+		"es/no-math-cbrt": "error",
+		"es/no-math-clz32": "error",
+		"es/no-math-cosh": "error",
+		"es/no-math-expm1": "error",
+		"es/no-math-fround": "error",
+		"es/no-math-hypot": "error",
+		"es/no-math-imul": "error",
+		"es/no-math-log10": "error",
+		"es/no-math-log1p": "error",
+		"es/no-math-log2": "error",
+		"es/no-math-sign": "error",
+		"es/no-math-sinh": "error",
+		"es/no-math-tanh": "error",
+		"es/no-math-trunc": "error",
+		"es/no-number-epsilon": "error",
+		"es/no-number-isfinite": "error",
+		"es/no-number-isinteger": "error",
+		"es/no-number-isnan": "error",
+		"es/no-number-issafeinteger": "error",
+		"es/no-number-maxsafeinteger": "error",
+		"es/no-number-minsafeinteger": "error",
+		"es/no-number-parsefloat": "error",
+		"es/no-number-parseint": "error",
+		"es/no-object-assign": "error",
+		"es/no-object-getownpropertysymbols": "error",
+		"es/no-object-is": "error",
+		"es/no-string-fromcodepoint": "error",
+		"es/no-string-raw": "error",
 		"no-restricted-properties": [
 			"error",
 			{
@@ -29,181 +63,12 @@ const rules = {
 				"message": "Unsupported method Array.prototype.copyWithin requires ES6."
 			},
 			{
-				"property": "entries",
-				"message": "Unsupported method Array.prototype.entries requires ES6."
-			},
-			{
 				"property": "fill",
 				"message": "Unsupported method Array.prototype.fill requires ES6."
 			},
 			{
 				"property": "findIndex",
 				"message": "Unsupported method Array.prototype.findIndex requires ES6."
-			},
-			{
-				"object": "String",
-				"property": "fromCodePoint",
-				"message": "Unsupported method String.fromCodePoint requires ES6."
-			},
-			{
-				"object": "String",
-				"property": "raw",
-				"message": "Unsupported method String.raw requires ES6."
-			},
-			{
-				"object": "Array",
-				"property": "from",
-				"message": "Unsupported method Array.from requires ES6."
-			},
-			{
-				"object": "Array",
-				"property": "of",
-				"message": "Unsupported method Array.of requires ES6."
-			},
-			{
-				"object": "Object",
-				"property": "assign",
-				"message": "Unsupported method Object.assign requires ES6."
-			},
-			{
-				"object": "Object",
-				"property": "getOwnPropertySymbols",
-				"message": "Unsupported method Object.getOwnPropertySymbols requires ES6."
-			},
-			{
-				"object": "Object",
-				"property": "is",
-				"message": "Unsupported method Object.is requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "isFinite",
-				"message": "Unsupported method Number.isFinite requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "isInteger",
-				"message": "Unsupported method Number.isInteger requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "isSafeInteger",
-				"message": "Unsupported method Number.isSafeInteger requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "isNaN",
-				"message": "Unsupported method Number.isNaN requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "parseFloat",
-				"message": "Unsupported method Number.parseFloat requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "parseInt",
-				"message": "Unsupported method Number.parseInt requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "EPSILON",
-				"message": "Unsupported property Number.EPSILON requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "MIN_SAFE_INTEGER",
-				"message": "Unsupported property Number.MIN_SAFE_INTEGER requires ES6."
-			},
-			{
-				"object": "Number",
-				"property": "MAX_SAFE_INTEGER",
-				"message": "Unsupported property Number.MAX_SAFE_INTEGER requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "clz32",
-				"message": "Unsupported method Math.clz32 requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "imul",
-				"message": "Unsupported method Math.imul requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "sign",
-				"message": "Unsupported method Math.sign requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "log10",
-				"message": "Unsupported method Math.log10 requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "log2",
-				"message": "Unsupported method Math.log2 requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "log1p",
-				"message": "Unsupported method Math.log1p requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "expm1",
-				"message": "Unsupported method Math.expm1 requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "cosh",
-				"message": "Unsupported method Math.cosh requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "sinh",
-				"message": "Unsupported method Math.sinh requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "tanh",
-				"message": "Unsupported method Math.tanh requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "acosh",
-				"message": "Unsupported method Math.acosh requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "asinh",
-				"message": "Unsupported method Math.asinh requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "atanh",
-				"message": "Unsupported method Math.atanh requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "trunc",
-				"message": "Unsupported method Math.trunc requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "fround",
-				"message": "Unsupported method Math.fround requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "cbrt",
-				"message": "Unsupported method Math.cbrt requires ES6."
-			},
-			{
-				"object": "Math",
-				"property": "hypot",
-				"message": "Unsupported method Math.hypot requires ES6."
 			}
 		],
 		"no-restricted-syntax": [
@@ -211,6 +76,10 @@ const rules = {
 			{
 				"selector": "CallExpression[callee.type='MemberExpression'][callee.property.type='Identifier'][callee.property.name='includes']",
 				"message": "Unsupported method String.prototype.includes requires ES6."
+			},
+			{
+				"selector": "CallExpression[callee.type='MemberExpression'][callee.property.type='Identifier'][callee.property.name='entries'][callee.object.name!='Object']",
+				"message": "Unsupported method Array.prototype.entries requires ES6."
 			},
 			{
 				"selector": "CallExpression[callee.type='MemberExpression'][callee.property.type='Identifier'][callee.property.name='find'][arguments.length=1][arguments.0.type='FunctionExpression']",

--- a/package-lock.json
+++ b/package-lock.json
@@ -320,9 +320,9 @@
           }
         },
         "regexpp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
         }
       }
     },

--- a/test/fixtures/client/invalid.js
+++ b/test/fixtures/client/invalid.js
@@ -20,10 +20,84 @@
 	''.codePointAt();
 	// eslint-disable-next-line no-restricted-syntax
 	[].keys();
+	// eslint-disable-next-line no-restricted-syntax
+	[].entries();
+	// eslint-disable-next-line es/no-array-from
+	Array.from();
+	// eslint-disable-next-line es/no-array-of
+	Array.of();
+	// eslint-disable-next-line es/no-math-acosh
+	Math.acosh();
+	// eslint-disable-next-line es/no-math-asinh
+	Math.asinh();
+	// eslint-disable-next-line es/no-math-atanh
+	Math.atanh();
+	// eslint-disable-next-line es/no-math-cbrt
+	Math.cbrt();
+	// eslint-disable-next-line es/no-math-clz32
+	Math.clz32();
+	// eslint-disable-next-line es/no-math-cosh
+	Math.cosh();
+	// eslint-disable-next-line es/no-math-expm1
+	Math.expm1();
+	// eslint-disable-next-line es/no-math-fround
+	Math.fround();
+	// eslint-disable-next-line es/no-math-hypot
+	Math.hypot();
+	// eslint-disable-next-line es/no-math-imul
+	Math.imul();
+	// eslint-disable-next-line es/no-math-log10
+	Math.log10();
+	// eslint-disable-next-line es/no-math-log1p
+	Math.log1p();
+	// eslint-disable-next-line es/no-math-log2
+	Math.log2();
+	// eslint-disable-next-line es/no-math-sign
+	Math.sign();
+	// eslint-disable-next-line es/no-math-sinh
+	Math.sinh();
+	// eslint-disable-next-line es/no-math-tanh
+	Math.tanh();
+	// eslint-disable-next-line es/no-math-trunc
+	Math.trunc();
+	// eslint-disable-next-line es/no-number-epsilon
+	Number.EPSILON.toString();
+	// eslint-disable-next-line es/no-number-isfinite
+	Number.isFinite();
+	// eslint-disable-next-line es/no-number-isinteger
+	Number.isInteger();
+	// eslint-disable-next-line es/no-number-isnan
+	Number.isNaN();
+	// eslint-disable-next-line es/no-number-issafeinteger
+	Number.isSafeInteger();
+	// eslint-disable-next-line es/no-number-maxsafeinteger
+	Number.MAX_SAFE_INTEGER.toString();
+	// eslint-disable-next-line es/no-number-minsafeinteger
+	Number.MIN_SAFE_INTEGER.toString();
+	// eslint-disable-next-line es/no-number-parsefloat
+	Number.parseFloat();
+	// eslint-disable-next-line es/no-number-parseint
+	Number.parseInt();
+	// eslint-disable-next-line es/no-object-assign
+	Object.assign();
+	// eslint-disable-next-line es/no-object-getownpropertysymbols
+	Object.getOwnPropertySymbols();
+	// eslint-disable-next-line es/no-object-is
+	Object.is();
+	// eslint-disable-next-line es/no-string-fromcodepoint
+	String.fromCodePoint();
+	// eslint-disable-next-line es/no-string-raw
+	String.raw();
 
 	// not-es6
 	// eslint-disable-next-line no-restricted-syntax
 	[].includes();
+	// eslint-disable-next-line es/no-object-entries
+	Object.entries();
+	// eslint-disable-next-line es/no-object-getownpropertydescriptors
+	Object.getOwnPropertyDescriptors();
+	// eslint-disable-next-line es/no-object-values
+	Object.values();
 
 	// not-es2016
 	// eslint-disable-next-line no-restricted-properties


### PR DESCRIPTION
Don't bother with syntax errors as these are caught
by the parser, but having individual rules for builtin
methods makes them easier to selectively disable.

Also ensure Array.prototype.entries rule doesn't conflict
with Object.entries.

Part of #224