### PR TITLE
mediawiki: Update plugin to 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -336,9 +336,9 @@
       }
     },
     "eslint-plugin-mediawiki": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.2.3.tgz",
-      "integrity": "sha512-/6CB/VdwZHIsPZ5gZJ3amwHUbEgbL6DZULXWTRwKoS+2q5t8TS1hu+EX83a1hPrxGWFusfV+bvgOi15aXVXi4Q==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.2.4.tgz",
+      "integrity": "sha512-tvvLPTwXp5YpCh3tbfSq/tOFRRcgrje1GVOz+91qBzuHOY6gHOesXQSrryeG33rbbRztktIa7IggpWmi2Rsu3A==",
       "requires": {
         "eslint-plugin-vue": "^6.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-es": "^3.0.0",
 		"eslint-plugin-json": "^2.1.1",
-		"eslint-plugin-mediawiki": "^0.2.3",
+		"eslint-plugin-mediawiki": "^0.2.4",
 		"eslint-plugin-no-jquery": "^2.3.2",
 		"eslint-plugin-qunit": "^4.0.0",
 		"eslint-plugin-vue": "^6.1.2"

--- a/test/fixtures/mediawiki/valid.js
+++ b/test/fixtures/mediawiki/valid.js
@@ -15,5 +15,6 @@
 
 	// Rule: mediawiki/valid-package-file-require
 	require( './invalid.js' );
+	require( './../test.js' );
 	require( 'SomePackage' );
 }() );


### PR DESCRIPTION
Provides for better `valid-package-file-require` heuristics, and
links to documentation for the `class-doc` and `msg-doc` rules.