### PR TITLE
Rule fix: Add balanced:true to spaced-comment

### DIFF
--- a/common.json
+++ b/common.json
@@ -97,7 +97,10 @@
 		"space-in-parens": [ "error", "always", { "exceptions": [ "empty" ] } ],
 		"space-infix-ops": "error",
 		"space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
-		"spaced-comment": [ "error", "always", { "exceptions": [ "*", "!" ] } ],
+		"spaced-comment": [ "error", "always", {
+			"exceptions": [ "*", "!" ],
+			"block": { "balanced": true }
+		} ],
 		"switch-colon-spacing": [ "error", { "after": true, "before": false } ],
 		"unicode-bom": [ "error" ],
 		"valid-jsdoc": [ "error", {

--- a/test/fixtures/common/invalid.js
+++ b/test/fixtures/common/invalid.js
@@ -11,6 +11,12 @@ var APP;
 	// eslint-disable-next-line spaced-comment
 	//Example
 
+	// eslint-disable-next-line spaced-comment
+	/*Example*/
+
+	// eslint-disable-next-line spaced-comment
+	/* Example*/
+
 	APP.Example = function ( id, options ) {
 		var i, name, bar;
 

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -13,6 +13,7 @@
 
 	// Rule: spaced-comment
 	// Example
+	/* Example */
 
 	// Empty function declaration
 	function upHere() {}


### PR DESCRIPTION
Enforces the whitespace at the end of a block comment.
Previously we only enforced at the start.