### PR TITLE
Add 'overrides' to individual vue configs

### DIFF
--- a/test/fixtures/vue-common/invalid.vue
+++ b/test/fixtures/vue-common/invalid.vue
@@ -23,6 +23,10 @@
 	</div>
 </template>
 
+<style>
+</style>
+
+<!-- eslint-disable-next-line vue/component-tags-order -->
 <script>
 // @vue/component
 module.exports = {

--- a/vue-common.json
+++ b/vue-common.json
@@ -1,59 +1,62 @@
 {
-	"extends": [
-		"plugin:vue/recommended",
-		"./common",
-		"./vue-wrappers"
-	],
-	"rules": {
-		"vue/component-tags-order": [ "error", {
-			"order": [ "template", "script", "style" ]
-		} ],
-		"vue/html-indent": [ "error", "tab" ],
-		"vue/html-closing-bracket-newline": "off",
-		"vue/max-attributes-per-line": [ "warn", {
-			"singleline": 2,
-			"multiline": {
-				"max": 1,
-				"allowFirstLine": true
-			}
-		} ],
-		"vue/no-boolean-default": "error",
-		"vue/no-deprecated-scope-attribute": "error",
-		"vue/no-deprecated-slot-attribute": "error",
-		"vue/no-deprecated-slot-scope-attribute": "error",
-		"vue/no-reserved-component-names": "error",
-		"vue/no-static-inline-styles": "error",
-		"vue/no-unsupported-features": [ "error", {
-			"version": "2.6.11"
-		} ],
-		"vue/order-in-components": [ "error", {
-			"order": [
-				"el",
-				"name",
-				"parent",
-				"functional",
-				[ "delimiters", "comments" ],
-				[ "components", "directives", "filters" ],
-				"extends",
-				"mixins",
-				"provide",
-				"inject",
-				"inheritAttrs",
-				"model",
-				[ "props", "propsData" ],
-				"asyncData",
-				"data",
-				"computed",
-				"methods",
-				"watch",
-				"fetch",
-				"LIFECYCLE_HOOKS",
-				"head",
-				[ "template", "render" ],
-				"renderError"
-			]
-		} ],
-		"vue/padding-line-between-blocks": [ "error", "always" ],
-		"vue/v-on-function-call": "error"
-	}
+	"overrides": [ {
+		"files": [ "**/*.vue" ],
+		"extends": [
+			"plugin:vue/recommended",
+			"./common",
+			"./vue-wrappers"
+		],
+		"rules": {
+			"vue/component-tags-order": [ "error", {
+				"order": [ "template", "script", "style" ]
+			} ],
+			"vue/html-indent": [ "error", "tab" ],
+			"vue/html-closing-bracket-newline": "off",
+			"vue/max-attributes-per-line": [ "warn", {
+				"singleline": 2,
+				"multiline": {
+					"max": 1,
+					"allowFirstLine": true
+				}
+			} ],
+			"vue/no-boolean-default": "error",
+			"vue/no-deprecated-scope-attribute": "error",
+			"vue/no-deprecated-slot-attribute": "error",
+			"vue/no-deprecated-slot-scope-attribute": "error",
+			"vue/no-reserved-component-names": "error",
+			"vue/no-static-inline-styles": "error",
+			"vue/no-unsupported-features": [ "error", {
+				"version": "2.6.11"
+			} ],
+			"vue/order-in-components": [ "error", {
+				"order": [
+					"el",
+					"name",
+					"parent",
+					"functional",
+					[ "delimiters", "comments" ],
+					[ "components", "directives", "filters" ],
+					"extends",
+					"mixins",
+					"provide",
+					"inject",
+					"inheritAttrs",
+					"model",
+					[ "props", "propsData" ],
+					"asyncData",
+					"data",
+					"computed",
+					"methods",
+					"watch",
+					"fetch",
+					"LIFECYCLE_HOOKS",
+					"head",
+					[ "template", "render" ],
+					"renderError"
+				]
+			} ],
+			"vue/padding-line-between-blocks": [ "error", "always" ],
+			"vue/v-on-function-call": "error"
+		}
+	} ]
 }

--- a/vue-es5.js
+++ b/vue-es5.js
@@ -1,25 +1,28 @@
 /* eslint-disable quote-props, quotes */
 module.exports = {
-	"extends": [
-		"./vue-es6",
-		// We can't use ./language/es5 here, because ecmaVersion: 5 breaks the Vue plugin
-		// Instead, use es/no-2015 to prohibit ES6+ syntax
-		"./language/not-es5",
-		"plugin:es/no-2015"
-	],
-	"plugins": [ "es" ],
-	// The Vue plugin sets sourceType: "module" and enables JSX: undo those things
-	"parserOptions": {
-		"sourceType": "script",
-		"ecmaFeatures": {
-			"jsx": false
+	"overrides": [ {
+		"files": [ "**/*.vue" ],
+		"extends": [
+			"./vue-es6",
+			// We can't use ./language/es5 here, because ecmaVersion: 5 breaks the Vue plugin
+			// Instead, use es/no-2015 to prohibit ES6+ syntax
+			"./language/not-es5",
+			"plugin:es/no-2015"
+		],
+		"plugins": [ "es" ],
+		// The Vue plugin sets sourceType: "module" and enables JSX: undo those things
+		"parserOptions": {
+			"sourceType": "script",
+			"ecmaFeatures": {
+				"jsx": false
+			}
+		},
+		"env": {
+			"es6": false
+		},
+		"rules": {
+			// This is a wrapper rule, but it can't be in vue-wrappers because it's ES5-specific
+			"vue/no-restricted-syntax": require( './language/not-es5' ).rules[ 'no-restricted-syntax' ]
 		}
-	},
-	"env": {
-		"es6": false
-	},
-	"rules": {
-		// This is a wrapper rule, but it can't be in vue-wrappers because it's ES5-specific
-		"vue/no-restricted-syntax": require( './language/not-es5' ).rules[ 'no-restricted-syntax' ]
-	}
+	} ]
 };

--- a/vue-es6.js
+++ b/vue-es6.js
@@ -1,11 +1,14 @@
 /* eslint-disable quote-props, quotes */
 module.exports = {
-	"extends": [
-		"./vue-common",
-		"./language/es6"
-	],
-	"rules": {
-		// This is a wrapper rule, but it can't be in vue-wrappers because it's ES6-specific
-		"vue/no-restricted-syntax": require( './language/not-es6' ).rules[ 'no-restricted-syntax' ]
-	}
+	"overrides": [ {
+		"files": [ "**/*.vue" ],
+		"extends": [
+			"./vue-common",
+			"./language/es6"
+		],
+		"rules": {
+			// This is a wrapper rule, but it can't be in vue-wrappers because it's ES6-specific
+			"vue/no-restricted-syntax": require( './language/not-es6' ).rules[ 'no-restricted-syntax' ]
+		}
+	} ]
 };


### PR DESCRIPTION
As of ESLint 7, overrides is used to work out which files the linter should target. As we recommend that these configs can be used outside of 'mediawiki' config, they should each individually have the overrides property set.