### PR TITLE
qunit: Fix inheritance

### DIFF
--- a/qunit.json
+++ b/qunit.json
@@ -1,6 +1,5 @@
 {
 	"extends": [
-		"./common",
 		"plugin:qunit/recommended",
 		"plugin:qunit/two"
 	],

--- a/test/fixtures/qunit/.eslintrc.json
+++ b/test/fixtures/qunit/.eslintrc.json
@@ -1,4 +1,7 @@
 {
 	"root": true,
-	"extends": "../../../qunit"
+	"extends": [
+		"../../../client",
+		"../../../qunit"
+	]
 }

--- a/test/fixtures/qunit/invalid.js
+++ b/test/fixtures/qunit/invalid.js
@@ -1,4 +1,3 @@
-/* eslint-env qunit */
 QUnit.module( 'Example' );
 
 QUnit.test( '.foo()', function ( assert ) {


### PR DESCRIPTION
`qunit` is used as a 'mixin' along with another config to set
the environment, e.g. `client`+`qunit`, or `server`+`qunit`.

By extending `common`, any overrides to `common` in `client`/`server`
would be overwritten if `qunit` is pulled in after `client`/`server`.