### PR TITLE
Docs: Fix QUnit example now inheritance is fixed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,8 +71,8 @@ You can extend the above profile by also adding a second `.eslintrc.json` file i
 ```json
 {
 	"extends": [
-		"wikimedia/qunit",
-		"../../.eslintrc.json"
+		"../../.eslintrc.json",
+		"wikimedia/qunit"
 	]
 }
 ```


### PR DESCRIPTION
Putting `qunit` first was a workaround to the fact that it extended `common`. It makes more sense to put your base rules first.