### PR TITLE
es6: Remove arrow-body-style

### DIFF
--- a/language/rules-es6.json
+++ b/language/rules-es6.json
@@ -1,7 +1,6 @@
 {
 	"extends": "./rules-es5",
 	"rules": {
-		"arrow-body-style": "error",
 		"arrow-parens": "error",
 		"arrow-spacing": "error",
 		"default-param-last": "error",

--- a/test/fixtures/server/invalid.js
+++ b/test/fixtures/server/invalid.js
@@ -13,7 +13,7 @@
 	// eslint-disable-next-line prefer-const
 	let f = ( p ) => p;
 
-	// eslint-disable-next-line arrow-body-style, arrow-parens, arrow-spacing
+	// eslint-disable-next-line arrow-parens, arrow-spacing
 	Object.keys( foo ).map( x=> {
 		return x + 1;
 	} );

--- a/test/fixtures/server/valid.js
+++ b/test/fixtures/server/valid.js
@@ -8,7 +8,6 @@
 	// Rule: prefer-const
 	const a = 4;
 
-	// Rule: arrow-body-style
 	// Rule: arrow-parens
 	// Rule: arrow-spacing
 	global.then( ( data ) => Math.pow( data, 2 ) );


### PR DESCRIPTION
Partial revert of #244.

In testing this rule often triggers in cases where the full body style is used to improve legibility.