### PR TITLE
jsduck: Remove this->context tag preference

### DIFF
--- a/jsduck.json
+++ b/jsduck.json
@@ -3,7 +3,6 @@
 	"settings": {
 		"jsdoc": {
 			"tagNamePreference": {
-				"this": "context",
 				"alias": "alternateClassName",
 				"typedef": "type"
 			}

--- a/test/fixtures/jsduck/invalid.js
+++ b/test/fixtures/jsduck/invalid.js
@@ -2,11 +2,6 @@
 
 	// eslint-disable-next-line jsdoc/check-tag-names
 	/**
-	 * @this Foo
-	 */
-
-	// eslint-disable-next-line jsdoc/check-tag-names
-	/**
 	 * @alias Bar
 	 */
 

--- a/test/fixtures/jsduck/valid.js
+++ b/test/fixtures/jsduck/valid.js
@@ -34,7 +34,6 @@
 
 	// Some different aliases are used in jsduck:
 	/**
-	 * @context {jQuery}
 	 * @alternateClassName otherName
 	 * @type {Object}
 	 */


### PR DESCRIPTION
'context' only exists as a custom tag in our repos, so rather than codifying it here we can just rename the custom tag to 'this' downstream, making migration to JSDoc slightly easier.