### PR TITLE
vue-es5: Don't inherit from vue-es6

### DIFF
--- a/vue-es5.js
+++ b/vue-es5.js
@@ -5,15 +5,19 @@ module.exports = {
 	"overrides": [ {
 		"files": [ "**/*.vue" ],
 		"extends": [
-			"./vue-es6",
+			"./vue-common",
 			// We can't use ./language/es5 here, because ecmaVersion: 5 breaks the Vue plugin
-			// Instead, use es/no-2015 to prohibit ES6+ syntax
+			// Instead, use ES6, then es/no-2015 to prohibit ES6+ syntax
+			// But don't use ./language/es-6 directly, because we don't want rules-es6
+			"./language/rules-es5",
 			"./language/not-es5",
 			"plugin:es/no-2015"
 		],
 		"plugins": [ "es" ],
 		// The Vue plugin sets sourceType: "module" and enables JSX: undo those things
 		"parserOptions": {
+			// ecmaVersion: 5 breaks the Vue plugin, we have to use 6 (see also above)
+			"ecmaVersion": 6,
 			"sourceType": "script",
 			"ecmaFeatures": {
 				"jsx": false


### PR DESCRIPTION
This causes problems, because it also inherits ES6-specific rules like
no-var, and then tries to apply those to ES5 code.

Instead, inherit from vue-common and rules-es5, and manually set
ecmaVersion: 6.