### PR TITLE
jsdoc: Drop @constant->@const, @description->@desc preferences

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -4,8 +4,6 @@
 		"jsdoc": {
 			"tagNamePreference": {
 				"augments": "extends",
-				"constant": "const",
-				"description": "desc",
 				"func": "method",
 				"function": "method",
 				"linkcode": "link",

--- a/test/fixtures/jsdoc/invalid.js
+++ b/test/fixtures/jsdoc/invalid.js
@@ -171,17 +171,7 @@
 
 	// eslint-disable-next-line jsdoc/check-tag-names
 	/**
-	 * @constant
-	 */
-
-	// eslint-disable-next-line jsdoc/check-tag-names
-	/**
 	 * @defaultvalue
-	 */
-
-	// eslint-disable-next-line jsdoc/check-tag-names
-	/**
-	 * @description Description.
 	 */
 
 	// eslint-disable-next-line jsdoc/check-tag-names
@@ -242,6 +232,16 @@
 	// eslint-disable-next-line jsdoc/check-tag-names
 	/**
 	 * @exception {Error}
+	 */
+
+	// eslint-disable-next-line jsdoc/check-tag-names
+	/**
+	 * @const
+	 */
+
+	// eslint-disable-next-line jsdoc/check-tag-names
+	/**
+	 * @desc
 	 */
 
 	// eslint-disable-next-line jsdoc/check-tag-names

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -22,8 +22,6 @@
 	 * Non-default aliases:
 	 *
 	 * @extends Foo
-	 * @const
-	 * @desc
 	 * @method
 	 * @link
 	 * @mixins
@@ -117,11 +115,11 @@
 	 * @class
 	 * @constructor
 	 * @constructs
-	 * @const
+	 * @constant
 	 * @default
 	// Off: jsdoc/check-indentation
-	 * @desc Multi-
-	 *       line
+	 * @description Multi-
+	 *              line
 	 * @external String
 	 * @file Multi-
 	 *       line


### PR DESCRIPTION
They are almost never used:
https://codesearch.wmflabs.org/search/?q=%5C%40const(%20%7C%24)&i=nope&files=.js&repos=
https://codesearch.wmflabs.org/search/?q=%5C%40desc(%20%7C%24)&i=nope&files=.js&repos=

and they are not jsduck builtins:
https://github.com/senchalabs/jsduck/wiki