### PR TITLE
jsdoc/jsduck: Move @mixes->@mixins to jsduck

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -8,7 +8,6 @@
 				"function": "method",
 				"linkcode": "link",
 				"linkplain": "link",
-				"mixes": "mixins",
 				"returns": "return",
 				"yields": "yield",
 

--- a/jsduck.json
+++ b/jsduck.json
@@ -4,6 +4,7 @@
 		"jsdoc": {
 			"tagNamePreference": {
 				"alias": "alternateClassName",
+				"mixes": "mixins",
 				"typedef": "type"
 			}
 		}

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -24,7 +24,6 @@
 	 * @extends Foo
 	 * @method
 	 * @link
-	 * @mixins
 	 * @yield
 	 *
 	 * Extra tags:
@@ -51,7 +50,7 @@
 	 *
 	 * @class
 	 *
-	 * @mixins App
+	 * @mixes App
 	 * @param {string} id
 	 * @param {Object} options
 	 */

--- a/test/fixtures/jsduck/valid.js
+++ b/test/fixtures/jsduck/valid.js
@@ -4,6 +4,7 @@
 	// Valid: settings.jsdoc.tagNamePreference
 	/**
 	 * @alternateClassName
+	 * @mixins
 	 * @type {Object}
 	 */
 


### PR DESCRIPTION
jsduck contains @mixins and not @mixes:
https://github.com/senchalabs/jsduck/wiki

jsdoc contains @mixes and not @mixins:
https://jsdoc.app/

Fixes #272