### PR TITLE
Vue: Prohibit self-closing tags, but allow shorthand attributes

### DIFF
--- a/mediawiki.json
+++ b/mediawiki.json
@@ -20,9 +20,13 @@
 			"rules": {
 				"no-implicit-globals": "off",
 				"mediawiki/no-vue-dynamic-i18n": "error",
-				"vue/v-bind-style": [ "error", "longform" ],
-				"vue/v-slot-style": [ "error", "longform" ],
-				"vue/v-on-style": [ "error", "longform" ]
+				"vue/html-self-closing": [ "error", {
+					"html": {
+						"void": "never",
+						"normal": "never",
+						"component": "never"
+					}
+				} ]
 			}
 		}
 	]

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ This config adds the jQuery `$` global, and additional rules preventing the use 
 ```
 
 #### MediaWiki
-Code that runs in MediaWiki can use this config. It enforces rules that are specific to the MediaWiki codebase (core and extensions), such as correct documentation of `mw.message` usage. It also automatically applies the Vue plugin and Vue-specific rules to `.vue` files, including MediaWiki-specific Vue rules such as prohibiting ES6 syntax and prohibiting shorthand syntax for `v-bind`, `v-on` and `v-slot`.
+Code that runs in MediaWiki can use this config. It enforces rules that are specific to the MediaWiki codebase (core and extensions), such as correct documentation of `mw.message` usage. It also automatically applies the Vue plugin and Vue-specific rules to `.vue` files, including MediaWiki-specific Vue rules such as prohibiting ES6 syntax and prohibiting self-closing tags.
 `.eslintrc.json`:
 ```json
 {

--- a/test/fixtures/mediawiki/invalid.vue
+++ b/test/fixtures/mediawiki/invalid.vue
@@ -1,23 +1,27 @@
 <template>
 	<div>
 		<!-- eslint-disable-next-line vue/v-bind-style -->
-		<a :href="foo">Foo</a>
+		<a v-bind:href="foo">Foo</a>
 		<!-- eslint-disable-next-line vue/v-on-style -->
-		<a @click="onClick">Click me</a>
+		<a v-on:click="onClick">Click me</a>
 		<blah-component>
 			<!-- eslint-disable-next-line vue/v-slot-style -->
-			<template #default>
+			<template v-slot:default>
 				foo
 			</template>
 			<!-- eslint-disable-next-line vue/v-slot-style -->
-			<template #bar>
+			<template v-slot:bar>
 				bar
 			</template>
 		</blah-component>
+		<!-- eslint-disable-next-line vue/html-self-closing -->
+		<p v-i18n-html:foo />
+		<!-- eslint-disable-next-line vue/html-self-closing -->
+		<blah-component />
 		<!-- eslint-disable-next-line mediawiki/no-vue-dynamic-i18n -->
 		<p>{{ $i18n( foo ) }}</p>
 		<!-- eslint-disable-next-line mediawiki/no-vue-dynamic-i18n -->
-		<p v-i18n-html:[foo] />
+		<p v-i18n-html:[foo]></p>
 	</div>
 </template>
 

--- a/test/fixtures/mediawiki/valid.vue
+++ b/test/fixtures/mediawiki/valid.vue
@@ -1,18 +1,21 @@
 <template>
 	<div>
 		<!-- Valid: vue/v-bind-style -->
-		<a v-bind:href="foo">Foo</a>
+		<a :href="foo">Foo</a>
 		<!-- Valid: vue/v-on-style -->
-		<a v-on:click="onClick">Click me</a>
+		<a @click="onClick">Click me</a>
 		<blah-component>
 			<!-- Valid: vue/v-slot-style -->
-			<template v-slot:default>
+			<template #default>
 				foo
 			</template>
-			<template v-slot:bar>
+			<template #bar>
 				bar
 			</template>
 		</blah-component>
+		<!-- Valid: vue/html-self-closing -->
+		<p v-i18n-html:foo></p>
+		<blah-component></blah-component>
 	</div>
 </template>
 


### PR DESCRIPTION
MediaWiki core has switched from libxml (which supports self-closing
tags, but breaks shorthand attributes) to RemexHtml (which does the
reverse).