### PR TITLE
Update jsdoc plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -482,13 +482,13 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "28.5.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-28.5.1.tgz",
-			"integrity": "sha512-1XSWu8UnGwqO8mX3XKGofffL83VRt00ptq0m5OrTLFDN3At4x+/pJ8YHJONKhGC35TtjskcS9/RR6F9pjQ8c+w==",
+			"version": "29.1.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-29.1.3.tgz",
+			"integrity": "sha512-HEB8jPsWBGu++LffL4K8VZ7VXz0HELI1I3Qkv/+5oSekgrAo6I0AVgl5abecLbTQQZo0OaEcmTptiIspwDOu1w==",
 			"requires": {
 				"comment-parser": "^0.7.5",
 				"debug": "^4.1.1",
-				"jsdoctypeparser": "^7.0.0",
+				"jsdoctypeparser": "^8.0.0",
 				"lodash": "^4.17.15",
 				"regextras": "^0.7.1",
 				"semver": "^7.3.2",
@@ -973,9 +973,9 @@
 			}
 		},
 		"jsdoctypeparser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-7.0.0.tgz",
-			"integrity": "sha512-6vWPn5qSy+MbgCVjXsQKVkRywhs+IxFU7Chw72DKsWoGueYp6QX8eTc55+EA0yPGYfhmglb1gfi283asXirfGQ=="
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-8.0.0.tgz",
+			"integrity": "sha512-eLCs6s4JqN8TjFJfgdiLHRvogLhOAJz+5RIA2FtoMe6ZDyuvghvppnlIToqAEnVbxRqLMrfnNXpW8FpmR6IMBw=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"eslint": "^7.3.1",
 		"eslint-plugin-es": "^3.0.1",
-		"eslint-plugin-jsdoc": "^28.5.1",
+		"eslint-plugin-jsdoc": "^29.1.3",
 		"eslint-plugin-json": "^2.1.1",
 		"eslint-plugin-mediawiki": "^0.2.5",
 		"eslint-plugin-mocha": "^7.0.1",


### PR DESCRIPTION
v29.1.3 of the jsdoc plugin fixes an issue when using the require-param rule (part of plugin:jsdoc/recommended) in --fix mode (gajus/eslint-plugin-jsdoc#607).

Note that this also pulls in the breaking release [v29.0.0](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v29.0.0). Supposedly, that release would add spaces between union type items, i. e. turn `{string|number}` into `{string | number}`. However, I tried configuring this new version of the config in MediaWiki core, and it didn’t change any of the union types. I’m not sure if I’m doing something wrong or if there’s actually no change.