### PR TITLE
qunit: Update eslint-plugin-qunit to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -565,9 +565,9 @@
 			}
 		},
 		"eslint-plugin-qunit": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-4.3.0.tgz",
-			"integrity": "sha512-xyQtwoDHWDuIqH5cp8SV0N++gFGwxfMKwRyumsBnJ3INM6Mz/qWUhrCTastOvvAc98aoieu2X5Ht4LgaZ3a75Q=="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-5.0.0.tgz",
+			"integrity": "sha512-F1AuwxsJ4YgSQztd3OZCNtM3DXpiDF9bpXbVCBcBU+8l5WOAAxfJHNYqP3tOhEEbIJPRkcTgk0SAJPYtdVjBmQ=="
 		},
 		"eslint-plugin-vue": {
 			"version": "6.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,9 +72,9 @@
 			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
 		},
 		"ajv": {
-			"version": "6.12.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-			"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+			"version": "6.12.5",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -416,9 +416,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
-			"integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
+			"integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@eslint/eslintrc": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	],
 	"license": "MIT",
 	"dependencies": {
-		"eslint": "^7.8.1",
+		"eslint": "^7.9.0",
 		"eslint-plugin-es": "^3.0.1",
 		"eslint-plugin-jsdoc": "^30.2.1",
 		"eslint-plugin-json": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"eslint-plugin-mocha": "^8.0.0",
 		"eslint-plugin-no-jquery": "^2.5.0",
 		"eslint-plugin-node": "^11.1.0",
-		"eslint-plugin-qunit": "^4.3.0",
+		"eslint-plugin-qunit": "^5.0.0",
 		"eslint-plugin-vue": "^6.2.2",
 		"eslint-plugin-wdio": "^6.0.12"
 	},

--- a/qunit.json
+++ b/qunit.json
@@ -9,8 +9,8 @@
 	"plugins": [ "qunit" ],
 	"rules": {
 		"qunit/no-assert-equal": "error",
-		"qunit/no-early-return": "error",
-		"qunit/no-negated-ok": "error",
+		"qunit/no-assert-logical-expression": "off",
+		"qunit/no-conditional-assertions": "off",
 		"qunit/require-expect": [ "error", "never-except-zero" ]
 	}
 }

--- a/test/fixtures/qunit/valid.js
+++ b/test/fixtures/qunit/valid.js
@@ -2,10 +2,21 @@ QUnit.module( 'Example' );
 
 // Valid: qunit/require-expect
 QUnit.test( '.foo()', function ( assert ) {
-	var x = 'bar';
+	var x = 'bar',
+		y = 'baz';
+
 	// Valid: qunit/no-assert-equal
 	assert.strictEqual( x, 'bar' );
 
 	// Valid: qunit/no-negated-ok
 	assert.notOk( x );
+
+	// Valid: qunit/no-negated-ok
+	if ( x ) {
+		// Off: qunit/no-conditional-assertions
+		assert.ok( x );
+	}
+
+	// Off: qunit/no-assert-logical-expression
+	assert.ok( x && y );
 } );


### PR DESCRIPTION
Added to /recommended:
* no-early-return (already enabled here)
* no-negated-ok (already enabled here)
* no-assert-logical-expresison (disabled)
* no-conditional-assertions (disabled)

We can consider enabling no-assert-logical-expresison &
no-conditional-assertions later, but the use cases in
MW don't seem obviously wrong.