### PR TITLE
json: Disable max-len rule

### DIFF
--- a/json.json
+++ b/json.json
@@ -8,6 +8,7 @@
 	"rules": {
 		"json-es/use-valid-json": "error",
 		"indent": [ "error", "tab" ],
-		"strict": "off"
+		"strict": "off",
+		"max-len": "off"
 	}
 }

--- a/test/fixtures/json/valid.jsonc
+++ b/test/fixtures/json/valid.jsonc
@@ -1,2 +1,5 @@
-{}
+{
+	"max-len":
+																									[]// Off: max-len
+}
 // Off: strict


### PR DESCRIPTION
The rule only triggers on indentation, not long strings,
but generated files can have 25 levels of indentation.
