### PR TITLE
vue-common: Add "emits" and "setup" to order-in-components

### DIFF
--- a/vue-common.json
+++ b/vue-common.json
@@ -43,6 +43,8 @@
 					"inheritAttrs",
 					"model",
 					[ "props", "propsData" ],
+					"emits",
+					"setup",
 					"asyncData",
 					"data",
 					"computed",


### PR DESCRIPTION
These are new in Vue 3. Adding them does not break Vue 2 code, since it
won't be using these yet (except perhaps for Vue 2 code preparing to
migrate, which may add no-op "emits" properties)