### PR TITLE
Allow var blocks to be split and moved

### DIFF
--- a/common.json
+++ b/common.json
@@ -16,6 +16,7 @@
 	"rules": {
 		"array-bracket-spacing": [ "error", "always" ],
 		"array-callback-return": "error",
+		"block-scoped-var": "error",
 		"block-spacing": "error",
 		"brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
 		"camelcase": [ "error", { "properties": "always" } ],
@@ -94,7 +95,6 @@
 		"no-whitespace-before-property": "error",
 		"no-with": "error",
 		"object-curly-spacing": [ "error", "always" ],
-		"one-var": [ "error", "always" ],
 		"operator-linebreak": [ "error", "after" ],
 		"prefer-numeric-literals": "error",
 		"prefer-regex-literals": "error",
@@ -114,7 +114,6 @@
 		} ],
 		"switch-colon-spacing": [ "error", { "after": true, "before": false } ],
 		"unicode-bom": [ "error" ],
-		"vars-on-top": "error",
 		"wrap-iife": "error",
 		"yoda": [ "error", "never" ]
 	}

--- a/test/fixtures/common/invalid.js
+++ b/test/fixtures/common/invalid.js
@@ -4,7 +4,6 @@ var APP;
 ( function ( global ) {
 	// eslint-disable-next-line no-shadow
 	var APP;
-	// eslint-disable-next-line one-var
 	var upHere = function ( yArg ) {
 		var rArg = yArg.fooBar;
 		// eslint-disable-next-line semi
@@ -32,14 +31,15 @@ var APP;
 		// eslint-disable-next-line array-bracket-spacing, comma-dangle, comma-spacing
 		bar = [0, 1,];
 
-		// eslint-disable-next-line one-var, vars-on-top
-		var i;
-
 		// eslint-disable-next-line space-before-blocks, yoda
 		if ( 3 === bar ){
 			// eslint-disable-next-line block-spacing, brace-style, camelcase
 			return camel_case;}
 
+		// eslint-disable-next-line no-use-before-define
+		upHere( i );
+
+		var i;
 		// eslint-disable-next-line max-statements-per-line
 		if ( name ) { return i; }
 
@@ -156,8 +156,10 @@ var APP;
 
 		// eslint-disable-next-line no-unmodified-loop-condition
 		while ( bar ) {
-			named( bar );
+			var baz = named( bar );
 		}
+		// eslint-disable-next-line block-scoped-var
+		upHere( baz );
 
 		// eslint-disable-next-line array-callback-return
 		[].map( function ( x ) {

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -7,9 +7,7 @@
 // Valid: semi-style
 // Valid: unicode-bom
 ( function ( global ) {
-	var APP,
-		hasOwn = Object.prototype.hasOwnProperty,
-		APPHasOwnProperty = Object.prototype.hasOwnProperty.call( APP, 'hasOwn' );
+	var APP;
 
 	// Valid: spaced-comment
 	// Example
@@ -24,6 +22,11 @@
 		var rArg = yArg.fooBar;
 		return rArg + yArg.getQuux();
 	}
+
+	// Valid: one-var
+	// Valid: vars-on-top
+	var hasOwn = Object.prototype.hasOwnProperty;
+	var APPHasOwnProperty = Object.prototype.hasOwnProperty.call( APP, 'hasOwn' );
 
 	/**
 	 * Example description.
@@ -90,6 +93,9 @@
 			try {
 				return APP.loop( items );
 			} catch ( e ) {
+				// Valid: block-scoped-var
+				var e2 = upHere( e );
+				upHereAlso( e2 );
 			}
 			return null;
 		};


### PR DESCRIPTION
* Disabled one-var and vars-on-top rules
* Enables block-scoped-var rule to prevent confusing usage.
  no-use-before-define should catch other problematic uses of var.

Fixes #360
