### PR TITLE
qunit: Update eslint-plugin-qunit to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"eslint-plugin-mocha": "^8.1.0",
 				"eslint-plugin-no-jquery": "^2.5.0",
 				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-qunit": "^5.2.0",
+				"eslint-plugin-qunit": "^6.0.0",
 				"eslint-plugin-vue": "^7.7.0",
 				"eslint-plugin-wdio": "^6.0.12"
 			},
@@ -624,14 +624,15 @@
 			}
 		},
 		"node_modules/eslint-plugin-qunit": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-5.2.0.tgz",
-			"integrity": "sha512-vwvLfu67Qx2XOv8WIxTF4EcNgo7tRZBzqyZUXxMxY3QQE8RPbXEjvcFbYCtf+lQD5fceQejWttI3xbu13xvm0w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.0.0.tgz",
+			"integrity": "sha512-+R8z2umSTIiWcxmTQ9nGoML8DL0VQJg4C+E9OpJ2KF9QL4WL/FoayROeTG5Z9zhlZ2qqa+9WkZ1YD6mx89io8w==",
 			"dependencies": {
-				"eslint-utils": "^2.1.0"
+				"eslint-utils": "^2.1.0",
+				"requireindex": "^1.2.0"
 			},
 			"engines": {
-				"node": "10.x || 12.x || 13.x || >=14.0.0"
+				"node": "10.x || 12.x || >=14.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-qunit/node_modules/eslint-utils": {
@@ -1406,6 +1407,14 @@
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/requireindex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+			"engines": {
+				"node": ">=0.10.5"
 			}
 		},
 		"node_modules/resolve": {
@@ -2228,11 +2237,12 @@
 			}
 		},
 		"eslint-plugin-qunit": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-5.2.0.tgz",
-			"integrity": "sha512-vwvLfu67Qx2XOv8WIxTF4EcNgo7tRZBzqyZUXxMxY3QQE8RPbXEjvcFbYCtf+lQD5fceQejWttI3xbu13xvm0w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.0.0.tgz",
+			"integrity": "sha512-+R8z2umSTIiWcxmTQ9nGoML8DL0VQJg4C+E9OpJ2KF9QL4WL/FoayROeTG5Z9zhlZ2qqa+9WkZ1YD6mx89io8w==",
 			"requires": {
-				"eslint-utils": "^2.1.0"
+				"eslint-utils": "^2.1.0",
+				"requireindex": "^1.2.0"
 			},
 			"dependencies": {
 				"eslint-utils": {
@@ -2779,6 +2789,11 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+		},
+		"requireindex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
 		},
 		"resolve": {
 			"version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"eslint-plugin-mocha": "^8.1.0",
 		"eslint-plugin-no-jquery": "^2.5.0",
 		"eslint-plugin-node": "^11.1.0",
-		"eslint-plugin-qunit": "^5.2.0",
+		"eslint-plugin-qunit": "^6.0.0",
 		"eslint-plugin-vue": "^7.7.0",
 		"eslint-plugin-wdio": "^6.0.12"
 	},

--- a/qunit.json
+++ b/qunit.json
@@ -1,14 +1,15 @@
 {
 	"extends": [
-		"plugin:qunit/recommended",
-		"plugin:qunit/two"
+		"plugin:qunit/recommended"
 	],
 	"env": {
 		"qunit": true
 	},
 	"plugins": [ "qunit" ],
 	"rules": {
+		"qunit/no-arrow-tests": "off",
 		"qunit/no-assert-equal": "error",
+		"qunit/no-assert-equal-boolean": "off",
 		"qunit/no-assert-logical-expression": "off",
 		"qunit/no-conditional-assertions": "off",
 		"qunit/require-expect": [ "error", "never-except-zero" ]

--- a/test/fixtures/qunit/.eslintrc.json
+++ b/test/fixtures/qunit/.eslintrc.json
@@ -1,7 +1,8 @@
 {
 	"root": true,
 	"extends": [
-		"../../../client-es5",
+		"../../../client-es6",
+		"../../../language/es2017",
 		"../../../qunit"
 	]
 }

--- a/test/fixtures/qunit/invalid.js
+++ b/test/fixtures/qunit/invalid.js
@@ -3,7 +3,7 @@ QUnit.module( 'Example' );
 // Local rules
 // eslint-disable-next-line qunit/require-expect
 QUnit.test( '.foo()', function ( assert ) {
-	var x = 'bar';
+	const x = 'bar';
 
 	// eslint-disable-next-line qunit/no-assert-equal
 	assert.equal( x, 'bar' );
@@ -22,7 +22,7 @@ QUnit.test( '.foo()', function ( assert ) {
 // Recommended
 // eslint-disable-next-line qunit/no-identical-names, qunit/resolve-async
 QUnit.test( '.foo()', function ( assert ) {
-	var done = assert.async();
+	const done = assert.async();
 
 	// eslint-disable-next-line qunit/assert-args
 	assert.ok( 'result', 'message', 'extra' );
@@ -38,10 +38,15 @@ QUnit.test( '.foo()', function ( assert ) {
 	// eslint-disable-next-line qunit/no-ok-equality
 	assert.ok( done === 'bar' );
 
+	// eslint-disable-next-line qunit/no-compare-relation-boolean
+	assert.strictEqual( done > 3, true );
+
 	// eslint-disable-next-line qunit/no-throws-string
 	assert.throws( function () {
 	}, 'error message', 'An error should have been thrown' );
 
+	// eslint-disable-next-line qunit/require-object-in-propequal
+	assert.propEqual( done, 'foo' );
 } );
 
 // eslint-disable-next-line qunit/no-commented-tests
@@ -62,7 +67,6 @@ QUnit.init();
 // eslint-disable-next-line qunit/no-jsdump
 QUnit.jsDump( {} );
 
-// Two:
 // eslint-disable-next-line qunit/no-async-test, qunit/no-test-expect-argument, qunit/require-expect
 QUnit.asyncTest( 'Asynchronous test', 3, function () {
 	// eslint-disable-next-line qunit/no-qunit-start-in-tests
@@ -79,6 +83,31 @@ QUnit.asyncTest( 'Asynchronous test', 3, function () {
 
 	// eslint-disable-next-line qunit/no-global-assertions
 	strictEqual( 3, 4 );
+} );
+
+// eslint-disable-next-line qunit/no-async-module-callbacks
+QUnit.module( 'An async module', async function () {
+	QUnit.test( 'a passing test', function ( assert ) {
+		assert.ok( true );
+	} );
+
+	await Promise.resolve();
+
+	QUnit.test( 'another passing test', function ( assert ) {
+		assert.ok( true );
+	} );
+} );
+
+QUnit.module( 'outer module', function ( hooks ) {
+	QUnit.module( 'inner module', function () {
+		// eslint-disable-next-line qunit/no-hooks-from-ancestor-modules
+		hooks.beforeEach( function () {} );
+	} );
+} );
+
+QUnit.test( 'Parent', function () {
+	// eslint-disable-next-line qunit/no-nested-tests
+	QUnit.test( 'Child', function () {} );
 } );
 
 // eslint-disable-next-line qunit/no-qunit-push

--- a/test/fixtures/qunit/valid.js
+++ b/test/fixtures/qunit/valid.js
@@ -1,12 +1,16 @@
 QUnit.module( 'Example' );
 
+// Off: qunit/no-arrow-tests
 // Valid: qunit/require-expect
-QUnit.test( '.foo()', function ( assert ) {
-	var x = 'bar',
+QUnit.test( '.foo()', ( assert ) => {
+	const x = 'bar',
 		y = 'baz';
 
 	// Valid: qunit/no-assert-equal
 	assert.strictEqual( x, 'bar' );
+
+	// Off: qunit/no-assert-equal-boolean
+	assert.strictEqual( x, true );
 
 	// Valid: qunit/no-negated-ok
 	assert.notOk( x );


### PR DESCRIPTION
Enables:
* no-async-module-callbacks
* no-compare-relation-boolean
* no-hooks-from-ancestor-modules
* no-nested-tests
* require-object-in-propequal

Disables:
* no-arrow-tests
* no-assert-equal-boolean (#366)
