### PR TITLE
jsdoc: Update eslint-plugin-jsdoc to 32.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"eslint": "^7.17.0",
 				"eslint-plugin-compat": "^3.9.0",
 				"eslint-plugin-es": "^4.1.0",
-				"eslint-plugin-jsdoc": "^30.7.13",
+				"eslint-plugin-jsdoc": "^32.3.0",
 				"eslint-plugin-json-es": "^1.5.3",
 				"eslint-plugin-mediawiki": "^0.2.7",
 				"eslint-plugin-mocha": "^8.1.0",
@@ -298,11 +298,11 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
-			"integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
+			"integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==",
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -470,11 +470,11 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "30.7.13",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz",
-			"integrity": "sha512-YM4WIsmurrp0rHX6XiXQppqKB8Ne5ATiZLJe2+/fkp9l9ExXFr43BbAbjZaVrpCT+tuPYOZ8k1MICARHnURUNQ==",
+			"version": "32.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.0.tgz",
+			"integrity": "sha512-zyx7kajDK+tqS1bHuY5sapkad8P8KT0vdd/lE55j47VPG2MeenSYuIY/M/Pvmzq5g0+3JB+P3BJGUXmHxtuKPQ==",
 			"dependencies": {
-				"comment-parser": "^0.7.6",
+				"comment-parser": "1.1.2",
 				"debug": "^4.3.1",
 				"jsdoctypeparser": "^9.0.0",
 				"lodash": "^4.17.20",
@@ -484,6 +484,9 @@
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/debug": {
@@ -1920,9 +1923,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
-			"integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
+			"integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2108,11 +2111,11 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "30.7.13",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz",
-			"integrity": "sha512-YM4WIsmurrp0rHX6XiXQppqKB8Ne5ATiZLJe2+/fkp9l9ExXFr43BbAbjZaVrpCT+tuPYOZ8k1MICARHnURUNQ==",
+			"version": "32.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.0.tgz",
+			"integrity": "sha512-zyx7kajDK+tqS1bHuY5sapkad8P8KT0vdd/lE55j47VPG2MeenSYuIY/M/Pvmzq5g0+3JB+P3BJGUXmHxtuKPQ==",
 			"requires": {
-				"comment-parser": "^0.7.6",
+				"comment-parser": "1.1.2",
 				"debug": "^4.3.1",
 				"jsdoctypeparser": "^9.0.0",
 				"lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"eslint": "^7.17.0",
 		"eslint-plugin-compat": "^3.9.0",
 		"eslint-plugin-es": "^4.1.0",
-		"eslint-plugin-jsdoc": "^30.7.13",
+		"eslint-plugin-jsdoc": "^32.3.0",
 		"eslint-plugin-json-es": "^1.5.3",
 		"eslint-plugin-mediawiki": "^0.2.7",
 		"eslint-plugin-mocha": "^8.1.0",

--- a/test/fixtures/jsdoc/.eslintrc.json
+++ b/test/fixtures/jsdoc/.eslintrc.json
@@ -1,7 +1,7 @@
 {
 	"root": true,
 	"extends": [
-		"../../../client",
+		"../../../client-es6",
 		"../../../jsdoc"
 	],
 	"rules": {

--- a/test/fixtures/jsdoc/invalid.js
+++ b/test/fixtures/jsdoc/invalid.js
@@ -4,7 +4,7 @@
 	 * @property {Function} APP
 	 * @property {Function} APP
 	 */
-	var APP;
+	let APP;
 	/* eslint-enable jsdoc/check-property-names */
 
 	// eslint-disable-next-line jsdoc/require-property-type
@@ -86,6 +86,21 @@
 	 * @private
 	 */
 	APP.method = function () {
+	};
+
+	// eslint-disable-next-line jsdoc/require-yields
+	/**
+	 * @param {number} foo
+	 */
+	APP.async = function * quux( foo ) {
+		yield foo;
+	};
+
+	// eslint-disable-next-line jsdoc/require-yields-check
+	/**
+	 * @yield {number}
+	 */
+	APP.async = function * quux() {
 	};
 
 	// eslint-disable-next-line jsdoc/check-alignment

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -15,7 +15,7 @@
 	/**
 	 * @property {Object}
 	 */
-	var APP;
+	let APP;
 
 	// Valid: settings.jsdoc.tagNamePreference
 	/**
@@ -76,6 +76,11 @@
 	 */
 	APP.sum = function ( a, b ) {
 		return a + b;
+	};
+
+	// Off: jsdoc/require-throws
+	APP.err = function () {
+		throw new Error( 'Oops' );
 	};
 
 	// Off: jsdoc/check-examples


### PR DESCRIPTION
Enables require-yields and require-yields-check
