### PR TITLE
common: Remove no-multi-str rule

### DIFF
--- a/common.json
+++ b/common.json
@@ -63,7 +63,6 @@
 		"no-loop-func": "error",
 		"no-loss-of-precision": "error",
 		"no-multi-spaces": "error",
-		"no-multi-str": "error",
 		"no-multiple-empty-lines": [ "error", { "max": 1, "maxBOF": 0, "maxEOF": 0 } ],
 		"no-new": "error",
 		"no-new-func": "error",

--- a/test/fixtures/common/invalid.js
+++ b/test/fixtures/common/invalid.js
@@ -235,9 +235,6 @@ var APP;
 	APP.defaults =  {
 		// eslint-disable-next-line no-floating-decimal
 		decimal: .4,
-		// eslint-disable-next-line no-multi-str
-		multiStr: ' \
-',
 		/* eslint-disable no-multiple-empty-lines */
 
 

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -213,6 +213,8 @@
 		// Valid: quotes
 		first: 'Who',
 		default: 'is',
+		multiStr: ' \
+',
 		null: 'there?',
 		// Valid: object-curly-spacing
 		second: { value: { of: 'What' } },


### PR DESCRIPTION
The warning message reads:

> Multiline support is limited to browsers supporting ES5 only.

It existed to protect ES3 browsers per https://github.com/eslint/eslint/pull/133,
which we haven't needed to do for a while now.

Follows-up 53c67d32d2365, which copied this from node-services.