### PR TITLE
jsdoc: Update eslint-plugin-jsdoc to 36.0.8

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -41,11 +41,13 @@
 		"jsdoc/check-param-names": [ "warn", { "allowExtraTrailingParamDocs": true } ],
 		"jsdoc/check-values": "off",
 		"jsdoc/empty-tags": "off",
+		"jsdoc/require-asterisk-prefix": "error",
 		"jsdoc/require-jsdoc": "off",
 		"jsdoc/require-param-description": "off",
 		"jsdoc/require-property": "off",
 		"jsdoc/require-property-description": "off",
 		"jsdoc/require-property-name": "off",
-		"jsdoc/require-returns-description": "off"
+		"jsdoc/require-returns-description": "off",
+		"jsdoc/tag-lines": "off"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"eslint": "^7.23.0",
 				"eslint-plugin-compat": "^3.9.0",
 				"eslint-plugin-es": "^4.1.0",
-				"eslint-plugin-jsdoc": "^32.3.0",
+				"eslint-plugin-jsdoc": "^36.0.8",
 				"eslint-plugin-json-es": "^1.5.3",
 				"eslint-plugin-mediawiki": "^0.2.7",
 				"eslint-plugin-mocha": "^8.1.0",
@@ -59,6 +59,19 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/@es-joy/jsdoccomment": {
+			"version": "0.10.8",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.8.tgz",
+			"integrity": "sha512-3P1JiGL4xaR9PoTKUHa2N/LKwa2/eUdRqGwijMWWgBqbFEqJUVpmaOi2TcjcemrsRMgFLBzQCK4ToPhrSVDiFQ==",
+			"dependencies": {
+				"comment-parser": "1.2.4",
+				"esquery": "^1.4.0",
+				"jsdoc-type-pratt-parser": "1.1.1"
+			},
+			"engines": {
+				"node": "^12 || ^14 || ^16"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -316,11 +329,11 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
-			"integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+			"integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -347,11 +360,19 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 			"dependencies": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/deep-is": {
@@ -491,37 +512,31 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "32.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.0.tgz",
-			"integrity": "sha512-zyx7kajDK+tqS1bHuY5sapkad8P8KT0vdd/lE55j47VPG2MeenSYuIY/M/Pvmzq5g0+3JB+P3BJGUXmHxtuKPQ==",
+			"version": "36.0.8",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.8.tgz",
+			"integrity": "sha512-brNjHvRuBy5CaV01mSp6WljrO/T8fHNj0DXG38odOGDnhI7HdcbLKX7DpSvg2Rfcifwh8GlnNFzx13sI05t3bg==",
 			"dependencies": {
-				"comment-parser": "1.1.2",
-				"debug": "^4.3.1",
-				"jsdoctypeparser": "^9.0.0",
-				"lodash": "^4.17.20",
-				"regextras": "^0.7.1",
-				"semver": "^7.3.4",
+				"@es-joy/jsdoccomment": "0.10.8",
+				"comment-parser": "1.2.4",
+				"debug": "^4.3.2",
+				"esquery": "^1.4.0",
+				"jsdoc-type-pratt-parser": "^1.1.1",
+				"lodash": "^4.17.21",
+				"regextras": "^0.8.0",
+				"semver": "^7.3.5",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/debug": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-			"dependencies": {
-				"ms": "2.1.2"
+				"node": "^12 || ^14 || ^16"
 			},
-			"engines": {
-				"node": ">=6.0"
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -1106,15 +1121,12 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/jsdoctypeparser": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
-			"integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
-			"bin": {
-				"jsdoctypeparser": "bin/jsdoctypeparser"
-			},
+		"node_modules/jsdoc-type-pratt-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
+			"integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/json-schema-traverse": {
@@ -1356,9 +1368,9 @@
 			}
 		},
 		"node_modules/regextras": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-			"integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
 			"engines": {
 				"node": ">=0.1.14"
 			}
@@ -1727,6 +1739,16 @@
 				}
 			}
 		},
+		"@es-joy/jsdoccomment": {
+			"version": "0.10.8",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.8.tgz",
+			"integrity": "sha512-3P1JiGL4xaR9PoTKUHa2N/LKwa2/eUdRqGwijMWWgBqbFEqJUVpmaOi2TcjcemrsRMgFLBzQCK4ToPhrSVDiFQ==",
+			"requires": {
+				"comment-parser": "1.2.4",
+				"esquery": "^1.4.0",
+				"jsdoc-type-pratt-parser": "1.1.1"
+			}
+		},
 		"@eslint/eslintrc": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
@@ -1929,9 +1951,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
-			"integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ=="
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+			"integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1954,11 +1976,11 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"deep-is": {
@@ -2117,31 +2139,25 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "32.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.0.tgz",
-			"integrity": "sha512-zyx7kajDK+tqS1bHuY5sapkad8P8KT0vdd/lE55j47VPG2MeenSYuIY/M/Pvmzq5g0+3JB+P3BJGUXmHxtuKPQ==",
+			"version": "36.0.8",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.8.tgz",
+			"integrity": "sha512-brNjHvRuBy5CaV01mSp6WljrO/T8fHNj0DXG38odOGDnhI7HdcbLKX7DpSvg2Rfcifwh8GlnNFzx13sI05t3bg==",
 			"requires": {
-				"comment-parser": "1.1.2",
-				"debug": "^4.3.1",
-				"jsdoctypeparser": "^9.0.0",
-				"lodash": "^4.17.20",
-				"regextras": "^0.7.1",
-				"semver": "^7.3.4",
+				"@es-joy/jsdoccomment": "0.10.8",
+				"comment-parser": "1.2.4",
+				"debug": "^4.3.2",
+				"esquery": "^1.4.0",
+				"jsdoc-type-pratt-parser": "^1.1.1",
+				"lodash": "^4.17.21",
+				"regextras": "^0.8.0",
+				"semver": "^7.3.5",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -2554,10 +2570,10 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"jsdoctypeparser": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
-			"integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw=="
+		"jsdoc-type-pratt-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
+			"integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -2741,9 +2757,9 @@
 			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
 		},
 		"regextras": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-			"integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w=="
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ=="
 		},
 		"require-from-string": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"eslint": "^7.23.0",
 		"eslint-plugin-compat": "^3.9.0",
 		"eslint-plugin-es": "^4.1.0",
-		"eslint-plugin-jsdoc": "^32.3.0",
+		"eslint-plugin-jsdoc": "^36.0.8",
 		"eslint-plugin-json-es": "^1.5.3",
 		"eslint-plugin-mediawiki": "^0.2.7",
 		"eslint-plugin-mocha": "^8.1.0",

--- a/test/fixtures/jsdoc/invalid.js
+++ b/test/fixtures/jsdoc/invalid.js
@@ -1,4 +1,17 @@
 ( function () {
+	// eslint-disable-next-line jsdoc/multiline-blocks
+	/** No text on 0th line
+	 * ...
+	 */
+
+	/* eslint-disable jsdoc/no-multi-asterisks */
+	// eslint-disable-next-line jsdoc/multiline-blocks
+	/**
+	 * ...
+	 ** No multiple asterisks
+	 No text on last line */
+	/* eslint-enable jsdoc/no-multi-asterisks */
+
 	/* eslint-disable jsdoc/check-property-names */
 	/**
 	 * @property {Function} APP
@@ -54,9 +67,9 @@
 	};
 	/* eslint-enable jsdoc/require-returns, jsdoc/require-returns-check */
 
-	// eslint-disable-next-line jsdoc/implements-on-classes
+	// eslint-disable-next-line jsdoc/implements-on-classes, jsdoc/require-asterisk-prefix
 	/**
-	 * @implements {HTMLElement}
+	 @implements {HTMLElement}
 	 */
 	APP.method = function ( bar ) {
 		return bar;

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -3,8 +3,11 @@
 // Off: jsdoc/check-values
 // Off: jsdoc/empty-tags
 // Off: jsdoc/match-description
+// Off: jsdoc/match-name
 // Off: jsdoc/no-bad-blocks
 // Off: jsdoc/no-defaults
+// Off: jsdoc/no-missing-syntax
+// Off: jsdoc/no-restricted-syntax
 // Off: jsdoc/no-types
 // Off: jsdoc/require-file-overview
 // Off: jsdoc/require-hyphen-before-param-description
@@ -18,6 +21,7 @@
 	let APP;
 
 	// Valid: settings.jsdoc.tagNamePreference
+	// Off: jsdoc/tag-lines
 	/**
 	 * Non-default aliases:
 	 *
@@ -122,7 +126,7 @@
 	 * @constructs
 	 * @constant
 	 * @default
-	// Off: jsdoc/check-indentation
+	 * // Off: jsdoc/check-indentation
 	 * @description Multi-
 	 *              line
 	 * @external String


### PR DESCRIPTION
Enable new rule "jsdoc/require-asterisk-prefix"
