### PR TITLE
vue-common: Add new rules from upstream

### DIFF
--- a/test/fixtures/mediawiki/invalid.vue
+++ b/test/fixtures/mediawiki/invalid.vue
@@ -28,5 +28,8 @@
 <script>
 // @vue/component
 module.exports = {
+	components: {
+		BlahComponent: {}
+	}
 };
 </script>

--- a/test/fixtures/mediawiki/valid.vue
+++ b/test/fixtures/mediawiki/valid.vue
@@ -22,7 +22,9 @@
 <script>
 // @vue/component
 module.exports = {
-
+	components: {
+		BlahComponent: {}
+	}
 };
 
 // Off: no-implicit-globals

--- a/test/fixtures/vue2-common/invalid.vue
+++ b/test/fixtures/vue2-common/invalid.vue
@@ -1,10 +1,12 @@
 <template>
 	<!-- eslint-disable-next-line vue/html-indent, vue/max-attributes-per-line -->
-		<div one="1" two="2" three="3"
+	<div one="1" :two="quux2" three="3"
 		foo="bar">
-		<blah-component>
-			<!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -->
-			<template slot="foo">
+		<!-- eslint-disable-next-line vue/no-duplicate-attr-inheritance -->
+		<blah-component v-bind="$attrs">
+			<!-- eslint-disable-next-line max-len -->
+			<!-- eslint-disable-next-line vue/no-deprecated-slot-attribute, vue/no-useless-template-attributes -->
+			<template slot="foo" x="y">
 				foo
 			</template>
 			<!-- eslint-disable-next-line vue/no-deprecated-scope-attribute -->
@@ -16,12 +18,20 @@
 				{{ baz }}
 			</template>
 		</blah-component>
+		<!-- eslint-disable-next-line vue/no-unregistered-components -->
+		<foo-component />
 		<!-- eslint-disable-next-line vue/no-static-inline-styles -->
 		<span style="color: red">Red</span>
-		<!-- eslint-disable-next-line vue/v-on-function-call -->
-		<a @click="foo()">Click me</a>
-		<!-- eslint-disable-next-line vue/no-unsupported-features -->
-		<!-- Can't actually be covered, since it doesn't do anything (yet) when set to v2.6 -->
+		<!-- eslint-disable-next-line vue/no-unused-refs, vue/v-on-function-call -->
+		<a ref="link" @click="foo()">Click me</a>
+		<!-- eslint-disable-next-line vue/no-multiple-objects-in-class -->
+		<a :class="[ { foo: 'bar' }, { baz: 'quux' } ]" />
+		<!-- eslint-disable-next-line vue/no-unsupported-features, vue/no-v-model-argument -->
+		<blah-component v-model:foo="bar" />
+		<!-- eslint-disable-next-line vue/no-useless-mustaches -->
+		{{ 'hello' }}
+		<!-- eslint-disable-next-line vue/no-useless-v-bind, vue/no-v-text -->
+		<a :class="'foo'" v-text="bar" />
 	</div>
 </template><!-- eslint-disable-next-line vue/padding-line-between-blocks -->
 <style>
@@ -29,22 +39,45 @@
 
 <!-- eslint-disable-next-line vue/component-tags-order -->
 <script>
+import Vue from 'vue';
+
 // @vue/component
 module.exports = {
 	// eslint-disable-next-line max-len
 	// eslint-disable-next-line vue/no-reserved-component-names, vue/component-definition-name-casing
 	name: 'div',
+	model: {
+		// eslint-disable-next-line vue/no-invalid-model-keys
+		foo: 'bar'
+	},
 	props: {
 		foo: {
 			type: Boolean,
 			// eslint-disable-next-line vue/no-boolean-default
 			default: false
+		},
+		// eslint-disable-next-line vue/no-unused-properties
+		foo2: {
+			type: String,
+			required: true
+		}
+	},
+	computed: {
+		quux1: function () {
+			// eslint-disable-next-line vue/valid-next-tick
+			Vue.nextTick();
+			return 42;
+		},
+		quux2: function () {
+			// eslint-disable-next-line vue/no-use-computed-property-like-method
+			return this.quux1() / 2;
 		}
 	},
 	// eslint-disable-next-line vue/order-in-components
 	components: {
 		// eslint-disable-next-line vue/no-reserved-component-names, vue/no-unused-components
-		button: {}
+		button: {},
+		BlahComponent: {}
 	}
 };
 </script>

--- a/vue-common.json
+++ b/vue-common.json
@@ -22,11 +22,29 @@
 			"vue/no-deprecated-scope-attribute": "error",
 			"vue/no-deprecated-slot-attribute": "error",
 			"vue/no-deprecated-slot-scope-attribute": "error",
-			"vue/no-reserved-component-names": "error",
+			"vue/no-duplicate-attr-inheritance": "error",
+			"vue/no-invalid-model-keys": "error",
+			"vue/no-multiple-objects-in-class": "error",
+			"vue/no-reserved-component-names": [ "error", {
+				"disallowVueBuiltInComponents": true,
+				"disallowVue3BuiltInComponents": true
+			} ],
 			"vue/no-static-inline-styles": "error",
+			"vue/no-unregistered-components": "error",
 			"vue/no-unsupported-features": [ "error", {
 				"version": "2.6.11"
 			} ],
+			"vue/no-unused-properties": [ "error", {
+				"groups": [ "props", "data", "computed", "methods", "setup" ],
+				"deepData": false,
+				"ignorePublicMembers": true
+			} ],
+			"vue/no-unused-refs": "error",
+			"vue/no-use-computed-property-like-method": "error",
+			"vue/no-useless-mustaches": "error",
+			"vue/no-useless-template-attributes": "error",
+			"vue/no-useless-v-bind": "error",
+			"vue/no-v-text": "error",
 			"vue/order-in-components": [ "error", {
 				"order": [
 					"el",
@@ -57,7 +75,8 @@
 				]
 			} ],
 			"vue/padding-line-between-blocks": [ "error", "always" ],
-			"vue/v-on-function-call": "error"
+			"vue/v-on-function-call": "error",
+			"vue/valid-next-tick": "error"
 		}
 	} ]
 }


### PR DESCRIPTION
Upstream hasn't updated its "recommended" set in a long time, but many
of the new rules they added are useful. This adds:

- vue/no-duplicate-attr-inheritance
- vue/no-invalid-model-keys
- vue/no-multiple-objects-in-class
- vue/no-unregistered-components
- vue/no-unused-properties (check everything, not just props, but allow
  unused methods with a JSDoc @public tag)
- vue/no-unused-refs
- vue/no-use-computed-property-like-method
- vue/no-useless-mustaches
- vue/no-useless-template-attributes
- vue/no-useless-v-bind
- vue/no-v-text
- vue/valid-next-tick

For vue/no-reserved-component-names, also disallow built-in components,
for both Vue 2 and Vue 3 (regardless of which Vue version is used).

Fixes #392