### PR TITLE
common: Fix eslint comment exception in `max-len`

### DIFF
--- a/common.json
+++ b/common.json
@@ -38,7 +38,7 @@
 		"max-len": [ "warn", {
 			"code": 100,
 			"tabWidth": 4,
-			"ignorePattern": "^// eslint-.+",
+			"ignorePattern": "^[\\s]*(//|<!--) eslint-.+",
 			"ignoreUrls": true,
 			"ignoreComments": false,
 			"ignoreRegExpLiterals": true,

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -43,6 +43,9 @@
 		// Valid: max-len
 		bar = 'This is a long string that is indeed so long that it breaches the line length rules and thus would trigger a warning were it not for the over-ride.';
 
+		// Valid: max-len
+		// eslint-comments-starting-with-"eslint-"-are-allowed-to-be-any-length---------------------------
+
 		// Valid: space-infix-ops
 		this.total = upHere() + id;
 		name = options.bar ? upHereAlso( id ) : id;

--- a/test/fixtures/vue2-common/invalid.vue
+++ b/test/fixtures/vue2-common/invalid.vue
@@ -4,7 +4,6 @@
 		foo="bar">
 		<!-- eslint-disable-next-line vue/no-duplicate-attr-inheritance -->
 		<blah-component v-bind="$attrs">
-			<!-- eslint-disable-next-line max-len -->
 			<!-- eslint-disable-next-line vue/no-deprecated-slot-attribute, vue/no-useless-template-attributes -->
 			<template slot="foo" x="y">
 				foo
@@ -43,7 +42,6 @@ import Vue from 'vue';
 
 // @vue/component
 module.exports = {
-	// eslint-disable-next-line max-len
 	// eslint-disable-next-line vue/no-reserved-component-names, vue/component-definition-name-casing
 	name: 'div',
 	model: {


### PR DESCRIPTION
The pattern matches the entire line, so needs to include
any indenting whitespace. Also allow HTML comments for
other parsers (e.g. vue).
