### PR TITLE
language: Move unicorn/prefer-includes to es2016

### DIFF
--- a/language/rules-es2016.json
+++ b/language/rules-es2016.json
@@ -1,3 +1,7 @@
 {
-	"extends": "./rules-es6"
+	"extends": "./rules-es6",
+	"plugins": [ "unicorn" ],
+	"rules": [
+		"unicorn/prefer-includes": "error"
+	]
 }

--- a/language/rules-es2016.json
+++ b/language/rules-es2016.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./rules-es6",
 	"plugins": [ "unicorn" ],
-	"rules": [
+	"rules": {
 		"unicorn/prefer-includes": "error"
-	]
+	}
 }

--- a/language/rules-es6.json
+++ b/language/rules-es6.json
@@ -14,7 +14,6 @@
 		"no-var": "error",
 		"one-var": "off",
 		"vars-on-top": "off",
-		"prefer-const": "error",
-		"unicorn/prefer-includes": "error"
+		"prefer-const": "error"
 	}
 }


### PR DESCRIPTION
Array.prototype.includes() was introduced in ES2016, not in ES6.

Fixes #418.