### PR TITLE
qunit: Replace various rules with `no-loose-assertions`

### DIFF
--- a/qunit.json
+++ b/qunit.json
@@ -7,10 +7,13 @@
 	},
 	"plugins": [ "qunit" ],
 	"rules": {
+		"qunit/no-assert-equal": "off",
 		"qunit/no-assert-equal-boolean": "off",
 		"qunit/no-assert-logical-expression": "off",
-		"qunit/no-assert-ok": "error",
 		"qunit/no-conditional-assertions": "off",
+		"qunit/no-loose-assertions": "error",
+		"qunit/no-negated-ok": "off",
+		"qunit/no-ok-equality": "off",
 		"qunit/require-expect": [ "error", "never-except-zero" ]
 	}
 }

--- a/test/fixtures/qunit/invalid.js
+++ b/test/fixtures/qunit/invalid.js
@@ -5,8 +5,11 @@ QUnit.module( 'Example' );
 QUnit.test( '.foo()', function ( assert ) {
 	const x = 'bar';
 
-	// eslint-disable-next-line qunit/no-assert-equal
+	// eslint-disable-next-line qunit/no-loose-assertions
 	assert.equal( x, 'bar' );
+
+	// eslint-disable-next-line qunit/no-loose-assertions
+	assert.notEqual( x, 'bar' );
 
 	assert.expect( 3 );
 
@@ -15,11 +18,11 @@ QUnit.test( '.foo()', function ( assert ) {
 		return;
 	}
 
-	// eslint-disable-next-line qunit/no-assert-ok
-	assert.ok( x );
-
-	// eslint-disable-next-line qunit/no-assert-ok, qunit/no-negated-ok
+	// eslint-disable-next-line qunit/no-loose-assertions
 	assert.ok( !x );
+
+	// eslint-disable-next-line qunit/no-loose-assertions
+	assert.notOk( x );
 } );
 
 // Recommended
@@ -37,9 +40,6 @@ QUnit.test( '.foo()', function ( assert ) {
 		// eslint-disable-next-line qunit/no-async-in-loops
 		assert.async();
 	}
-
-	// eslint-disable-next-line qunit/no-assert-ok, qunit/no-ok-equality
-	assert.ok( done === 'bar' );
 
 	// eslint-disable-next-line qunit/no-compare-relation-boolean
 	assert.strictEqual( done > 3, true );

--- a/test/fixtures/qunit/valid.js
+++ b/test/fixtures/qunit/valid.js
@@ -2,9 +2,18 @@ QUnit.module( 'Example' );
 
 // Off: qunit/no-arrow-tests
 // Valid: qunit/require-expect
-QUnit.test( '.foo()', ( assert ) => {
+QUnit.test( '.foo()', () => {
+} );
+
+QUnit.test( '.bar()', function ( assert ) {
 	const x = 'bar',
 		y = 'baz';
+
+	// The following rules are superseded by qunit/no-loose-assertions,
+	// so are turned off to avoid double errors.
+	// Off: qunit/no-assert-equal
+	// Off: qunit/no-negated-ok
+	// Off: qunit/no-ok-equality
 
 	// Valid: qunit/no-assert-equal
 	assert.strictEqual( x, 'bar' );
@@ -13,14 +22,11 @@ QUnit.test( '.foo()', ( assert ) => {
 	assert.strictEqual( x, true );
 
 	// Valid: qunit/no-negated-ok
-	assert.notOk( x );
-
-	// Valid: qunit/no-negated-ok
 	if ( x ) {
 		// Off: qunit/no-conditional-assertions
-		assert.ok( x );
+		assert.true( x );
 	}
 
 	// Off: qunit/no-assert-logical-expression
-	assert.ok( x && y );
+	assert.true( x && y );
 } );


### PR DESCRIPTION
assert.equal/ok/notOk and various special cases of them were
covered by assorted rules.

Replace all these rules with `no-loose-assertions` which
also disallows assert.notEqual.
