### PR TITLE
mediawiki: Duplicate JSON override to prevent max-len applying to JSON

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -50,5 +50,8 @@ config.rules[ 'max-len' ][ 1 ].ignorePattern =
 		'|' +
 		'[\\s]*(//|<!--) *\\* ?[\\S]+$' +
 	')';
+// Duplicate JSON override from common rules to prevent max-len rule here taking precedent
+const jsonOverride = commonRules.overrides.find( ( override ) => override.parser === 'eslint-plugin-json-es' );
+config.overrides.push( jsonOverride );
 
 module.exports = config;

--- a/test/fixtures/mediawiki/valid.jsonc
+++ b/test/fixtures/mediawiki/valid.jsonc
@@ -1,3 +1,4 @@
 {
-	"classes": { "foo": "bar" } // class-doc doesn't crash on JSON input
+	"classes": { "foo": "bar" }, // class-doc doesn't crash on JSON input
+	"max-len-off": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc a ligula ut felis volutpat venenatis. Vivamus venenatis justo in lectus tempus placerat."
 }


### PR DESCRIPTION
The new max-len rule in the mediawiki config takes precedent
over the inherited override from the common config.

Copy over the override to prevent max-len from triggering on
JSON files under the mediawiki config.
