### PR TITLE
qunit: Update eslint-plugin-qunit to 7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -862,9 +862,9 @@
 			}
 		},
 		"eslint-plugin-qunit": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.0.0.tgz",
-			"integrity": "sha512-yPh02tbQoZK43voIfJFO9CUN5Q6j8ebfrnxEqPr7I4UiYln4RWKDQ4ajaHgV3gJKSAUZwymJ0DsB/YH6btRxIQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
+			"integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
 			"requires": {
 				"eslint-utils": "^3.0.0",
 				"requireindex": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"eslint-plugin-mocha": "^9.0.0",
 		"eslint-plugin-no-jquery": "^2.7.0",
 		"eslint-plugin-node": "^11.1.0",
-		"eslint-plugin-qunit": "^7.0.0",
+		"eslint-plugin-qunit": "^7.2.0",
 		"eslint-plugin-unicorn": "^37.0.1",
 		"eslint-plugin-vue": "^8.0.2",
 		"eslint-plugin-wdio": "^7.4.2",

--- a/test/fixtures/qunit/invalid.js
+++ b/test/fixtures/qunit/invalid.js
@@ -27,7 +27,7 @@ QUnit.test( '.foo()', function ( assert ) {
 
 // Recommended
 // eslint-disable-next-line qunit/no-identical-names, qunit/resolve-async
-QUnit.test( '.foo()', function ( assert ) {
+QUnit.test( '.foo()', ( assert ) => {
 	const done = assert.async();
 
 	// eslint-disable-next-line qunit/assert-args


### PR DESCRIPTION
Fixes application of rules to arrow function tests
which we fixed upstream.
