### PR TITLE
vue: Enforce component-name-in-template-casing

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -36,7 +36,8 @@ const config = {
 						"normal": "never",
 						"component": "never"
 					}
-				} ]
+				} ],
+				"vue/component-name-in-template-casing": [ "error", "kebab-case" ]
 			}
 		}
 	]

--- a/test/fixtures/mediawiki/invalid.vue
+++ b/test/fixtures/mediawiki/invalid.vue
@@ -19,6 +19,8 @@
 		<p v-i18n-html:foo />
 		<!-- eslint-disable-next-line vue/html-self-closing, vue/no-unregistered-components -->
 		<blah-component />
+		<!-- eslint-disable-next-line vue/component-name-in-template-casing -->
+		<BlahComponent></BlahComponent>
 		<!-- eslint-disable-next-line mediawiki/no-vue-dynamic-i18n -->
 		<p>{{ $i18n( foo ) }}</p>
 		<!-- eslint-disable-next-line mediawiki/no-vue-dynamic-i18n -->
@@ -30,7 +32,12 @@
 // eslint-disable-next-line mediawiki/valid-package-file-require
 require( './invalid' );
 // eslint-disable-next-line mediawiki/vue-exports-component-directive
+module.exports = {};
+
+// @vue/component
 module.exports = {
+	// eslint-disable-next-line vue/multi-word-component-names
+	name: 'Invalid',
 	components: {
 		BlahComponent: {}
 	}

--- a/test/fixtures/mediawiki/valid.vue
+++ b/test/fixtures/mediawiki/valid.vue
@@ -15,6 +15,7 @@
 		</blah-component>
 		<!-- Valid: vue/html-self-closing -->
 		<p v-i18n-html:foo></p>
+		<!-- Valid: vue/component-name-in-template-casing -->
 		<blah-component></blah-component>
 	</div>
 </template>

--- a/test/fixtures/vue2-common/invalid.vue
+++ b/test/fixtures/vue2-common/invalid.vue
@@ -3,7 +3,7 @@
 	<div one="1" :two="quux2" three="3"
 		foo="bar">
 		<!-- eslint-disable-next-line vue/no-duplicate-attr-inheritance -->
-		<blah-component v-bind="$attrs">
+		<BlahComponent v-bind="$attrs">
 			<!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -->
 			<template slot="foo">
 				foo
@@ -16,7 +16,7 @@
 			<template #quux="bar" slot-scope="baz">
 				{{ baz }}
 			</template>
-		</blah-component>
+		</BlahComponent>
 		<!-- eslint-disable-next-line vue/no-unregistered-components -->
 		<foo-component />
 		<!-- eslint-disable-next-line vue/no-static-inline-styles -->
@@ -25,7 +25,7 @@
 		<a ref="link" @click="foo()">Click me</a>
 		<!-- eslint-disable-next-line vue/no-multiple-objects-in-class -->
 		<a :class="[ { foo: 'bar' }, { baz: 'quux' } ]" />
-		<!-- eslint-disable-next-line vue/no-unsupported-features, vue/no-v-model-argument -->
+		<!-- eslint-disable-next-line vue/no-unsupported-features, vue/no-v-model-argument, vue/component-name-in-template-casing -->
 		<blah-component v-model:foo="bar" />
 		<!-- eslint-disable-next-line vue/no-useless-mustaches -->
 		{{ 'hello' }}

--- a/test/fixtures/vue2-common/valid.vue
+++ b/test/fixtures/vue2-common/valid.vue
@@ -13,6 +13,8 @@
 		/>
 		<!-- Valid: vue/v-on-function-call -->
 		<a @click="foo">Click me</a>
+		<!-- Valid: vue/component-name-in-template-casing -->
+		<BlahComponent />
 		<!-- Valid: vue/padding-line-between-blocks -->
 	</div>
 </template>
@@ -27,7 +29,9 @@ module.exports = {
 	functional: false,
 	delimiters: [],
 	comments: [],
-	components: {},
+	components: {
+		BlahComponent: {}
+	},
 	directives: {},
 	filters: {},
 	extends: null,

--- a/vue-common.json
+++ b/vue-common.json
@@ -72,7 +72,8 @@
 				]
 			} ],
 			"vue/padding-line-between-blocks": [ "error", "always" ],
-			"vue/v-on-function-call": "error"
+			"vue/v-on-function-call": "error",
+			"vue/component-name-in-template-casing": [ "error", "PascalCase" ]
 		}
 	} ]
 }


### PR DESCRIPTION
In MediaWiki's environment, enforce kebab-case, since using PascalCase
leads to problems. In non-MW environments, enforce PascalCase, as
recommended in the Vue style guide.

Fixes #431.