### PR TITLE
Update eslint-plugin-vue to 8.2.0

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -36,6 +36,9 @@ const config = {
 						"normal": "never",
 						"component": "never"
 					}
+				} ],
+				"vue/no-child-content": [ "error", {
+					"additionalDirectives": [ "i18n-html" ]
 				} ]
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -913,79 +913,22 @@
 			}
 		},
 		"eslint-plugin-vue": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-8.0.2.tgz",
-			"integrity": "sha512-8X421wnZBOpH/cT6KljjMXCvkVNSABZa3+kBI/R+jgT+EUe6iy71LvtYKYd3nAnIHFYpY65tPYVzprzuSGJAcQ==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-8.2.0.tgz",
+			"integrity": "sha512-cLIdTuOAMXyHeQ4drYKcZfoyzdwdBpH279X8/N0DgmotEI9yFKb5O/cAgoie/CkQZCH/MOmh0xw/KEfS90zY2A==",
 			"requires": {
 				"eslint-utils": "^3.0.0",
 				"natural-compare": "^1.4.0",
 				"semver": "^7.3.5",
-				"vue-eslint-parser": "^8.0.0"
+				"vue-eslint-parser": "^8.0.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
-				},
-				"eslint-scope": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-					"integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
-					"requires": {
-						"esrecurse": "^4.3.0",
-						"estraverse": "^5.2.0"
-					}
-				},
 				"eslint-utils": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 					"requires": {
 						"eslint-visitor-keys": "^2.0.0"
-					}
-				},
-				"espree": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-					"integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
-					"requires": {
-						"acorn": "^8.5.0",
-						"acorn-jsx": "^5.3.1",
-						"eslint-visitor-keys": "^3.0.0"
-					},
-					"dependencies": {
-						"eslint-visitor-keys": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-							"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q=="
-						}
-					}
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-				},
-				"vue-eslint-parser": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-8.0.0.tgz",
-					"integrity": "sha512-YxN5bkPDji+XLQ4sx+ULLxckL+y/oS3xzgFRkcjJL2asfVcRhzbrNRwMtWgj/70fXsrr+hkFjkxze8PBZ5O3ug==",
-					"requires": {
-						"debug": "^4.3.2",
-						"eslint-scope": "^6.0.0",
-						"eslint-visitor-keys": "^3.0.0",
-						"espree": "^9.0.0",
-						"esquery": "^1.4.0",
-						"lodash": "^4.17.21",
-						"semver": "^7.3.5"
-					},
-					"dependencies": {
-						"eslint-visitor-keys": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-							"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q=="
-						}
 					}
 				}
 			}
@@ -1927,6 +1870,56 @@
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"vue-eslint-parser": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-8.0.1.tgz",
+			"integrity": "sha512-lhWjDXJhe3UZw2uu3ztX51SJAPGPey1Tff2RK3TyZURwbuI4vximQLzz4nQfCv8CZq4xx7uIiogHMMoSJPr33A==",
+			"requires": {
+				"debug": "^4.3.2",
+				"eslint-scope": "^6.0.0",
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0",
+				"esquery": "^1.4.0",
+				"lodash": "^4.17.21",
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.7.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+					"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+				},
+				"eslint-scope": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
+					"integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^5.2.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA=="
+				},
+				"espree": {
+					"version": "9.3.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
+					"integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+					"requires": {
+						"acorn": "^8.7.0",
+						"acorn-jsx": "^5.3.1",
+						"eslint-visitor-keys": "^3.1.0"
+					}
+				},
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+				}
 			}
 		},
 		"which": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-qunit": "^7.2.0",
 		"eslint-plugin-unicorn": "^37.0.1",
-		"eslint-plugin-vue": "^8.0.2",
+		"eslint-plugin-vue": "^8.2.0",
 		"eslint-plugin-wdio": "^7.4.2",
 		"eslint-plugin-yml": "^0.12.0"
 	},

--- a/test/fixtures/mediawiki/invalid.vue
+++ b/test/fixtures/mediawiki/invalid.vue
@@ -5,7 +5,7 @@
 		<!-- eslint-disable-next-line vue/v-on-style -->
 		<a v-on:click="onClick">Click me</a>
 		<!-- eslint-disable-next-line vue/no-unregistered-components -->
-		<blah-component>
+		<foo-component>
 			<!-- eslint-disable-next-line vue/v-slot-style -->
 			<template v-slot:default>
 				foo
@@ -14,11 +14,19 @@
 			<template v-slot:bar>
 				bar
 			</template>
-		</blah-component>
+		</foo-component>
 		<!-- eslint-disable-next-line vue/html-self-closing -->
 		<p v-i18n-html:foo />
-		<!-- eslint-disable-next-line vue/html-self-closing, vue/no-unregistered-components -->
+		<!-- eslint-disable-next-line vue/html-self-closing -->
 		<blah-component />
+		<!-- eslint-disable-next-line vue/no-child-content, vue/no-v-html -->
+		<p v-html="foo">
+			bar
+		</p>
+		<!-- eslint-disable-next-line vue/no-child-content -->
+		<p v-i18n-html:foo>
+			bar
+		</p>
 		<!-- eslint-disable-next-line mediawiki/no-vue-dynamic-i18n -->
 		<p>{{ $i18n( foo ) }}</p>
 		<!-- eslint-disable-next-line mediawiki/no-vue-dynamic-i18n -->
@@ -30,7 +38,12 @@
 // eslint-disable-next-line mediawiki/valid-package-file-require
 require( './invalid' );
 // eslint-disable-next-line mediawiki/vue-exports-component-directive
+module.exports = {};
+
+// @vue/component
 module.exports = {
+	// eslint-disable-next-line vue/multi-word-component-names
+	name: 'Invalid',
 	components: {
 		BlahComponent: {}
 	}

--- a/test/fixtures/mediawiki/valid.vue
+++ b/test/fixtures/mediawiki/valid.vue
@@ -17,6 +17,10 @@
 		<!-- Valid: vue/component-name-in-template-casing -->
 		<blah-component></blah-component>
 		<!-- Valid: vue/no-child-content -->
+		<!--
+			This line asserts valid code for the no-child-content rule, but there's no way
+			to do that without running afoul of the no-v-html rule
+		-->
 		<!-- eslint-disable-next-line vue/no-v-html -->
 		<p v-html="foo"></p>
 		<p v-i18n-html:foo></p>

--- a/test/fixtures/mediawiki/valid.vue
+++ b/test/fixtures/mediawiki/valid.vue
@@ -14,8 +14,11 @@
 			</template>
 		</blah-component>
 		<!-- Valid: vue/html-self-closing -->
-		<p v-i18n-html:foo></p>
 		<blah-component></blah-component>
+		<!-- Valid: vue/no-child-content -->
+		<!-- eslint-disable-next-line vue/no-v-html -->
+		<p v-html="foo"></p>
+		<p v-i18n-html:foo></p>
 	</div>
 </template>
 

--- a/test/fixtures/vue-wrappers/invalid.vue
+++ b/test/fixtures/vue-wrappers/invalid.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<!-- eslint-disable-next-line vue/array-bracket-spacing, vue/comma-spacing -->
-		<div :class="['foo' ,'bar']" />
+		<div :class="[foo ,bar]" />
 		<!-- eslint-disable-next-line vue/key-spacing, vue/object-curly-spacing -->
 		<a :class="{foo:'bar'}" />
 		<!-- eslint-disable-next-line vue/eqeqeq -->
@@ -30,7 +30,7 @@
 		<!-- eslint-disable-next-line vue/space-unary-ops -->
 		<a :href="! x" />
 		<!-- eslint-disable-next-line vue/comma-dangle -->
-		<div :class="[ 'foo', 'bar', ]" />
+		<div :class="[ foo, bar, ]" />
 		<!-- eslint-disable-next-line vue/no-multi-spaces -->
 		<a :href="16  + 23" />
 		<!-- eslint-disable vue/operator-linebreak -->

--- a/test/fixtures/vue-wrappers/valid.vue
+++ b/test/fixtures/vue-wrappers/valid.vue
@@ -2,7 +2,7 @@
 	<div>
 		<!-- Valid: vue/array-bracket-spacing -->
 		<!-- Valid: vue/comma-dangle -->
-		<div :class="[ 'foo', 'bar' ]" />
+		<div :class="[ foo, bar ]" />
 		<!-- Valid: vue/key-spacing -->
 		<!-- Valid: vue/object-curly-spacing -->
 		<a :class="{ foo: 'bar' }" />

--- a/test/fixtures/vue2-common/invalid.vue
+++ b/test/fixtures/vue2-common/invalid.vue
@@ -29,8 +29,10 @@
 		<blah-component v-model:foo="bar" />
 		<!-- eslint-disable-next-line vue/no-useless-mustaches -->
 		{{ 'hello' }}
-		<!-- eslint-disable-next-line vue/no-useless-v-bind, vue/no-v-text -->
-		<a :class="'foo'" v-text="bar" />
+		<!-- eslint-disable-next-line vue/no-useless-v-bind, vue/no-v-text-->
+		<a :href="'foo'" v-text="bar" />
+		<!-- eslint-disable-next-line vue/prefer-separate-static-class -->
+		<a :class="[ 'myClass', foo ]" />
 	</div>
 </template><!-- eslint-disable-next-line vue/padding-line-between-blocks -->
 <style>

--- a/test/fixtures/vue2-common/valid.vue
+++ b/test/fixtures/vue2-common/valid.vue
@@ -13,6 +13,11 @@
 		/>
 		<!-- Valid: vue/v-on-function-call -->
 		<a @click="foo">Click me</a>
+		<!-- Valid: vue/no-child-content -->
+		<!-- eslint-disable-next-line vue/no-v-html -->
+		<p v-html="foo" />
+		<!-- Valid: vue/prefer-separate-static-class -->
+		<div class="myDiv" :class="foo" />
 		<!-- Valid: vue/padding-line-between-blocks -->
 	</div>
 </template>

--- a/test/fixtures/vue2-common/valid.vue
+++ b/test/fixtures/vue2-common/valid.vue
@@ -16,6 +16,10 @@
 		<!-- Valid: vue/component-name-in-template-casing -->
 		<BlahComponent />
 		<!-- Valid: vue/no-child-content -->
+		<!--
+			This line asserts valid code for the no-child-content rule, but there's no way
+			to do that without running afoul of the no-v-html rule
+		-->
 		<!-- eslint-disable-next-line vue/no-v-html -->
 		<p v-html="foo" />
 		<!-- Valid: vue/prefer-separate-static-class -->

--- a/vue-common.json
+++ b/vue-common.json
@@ -72,7 +72,10 @@
 				]
 			} ],
 			"vue/padding-line-between-blocks": [ "error", "always" ],
-			"vue/v-on-function-call": "error"
+			"vue/v-on-function-call": "error",
+			"vue/no-child-content": "error",
+			"vue/no-expose-after-await": "error",
+			"vue/prefer-separate-static-class": "error"
 		}
 	} ]
 }


### PR DESCRIPTION
Add rules:
- vue/no-child-content
    - In MediaWiki, add v-i18n-html as an additional directive
- vue/no-expose-after-await
- vue/prefer-separate-static-class