### PR TITLE
Disable no-use-before-define for functions

### DIFF
--- a/common.json
+++ b/common.json
@@ -93,7 +93,7 @@
 		"no-unneeded-ternary": [ "error", { "defaultAssignment": false } ],
 		"no-unreachable-loop": "error",
 		"no-unused-expressions": "error",
-		"no-use-before-define": "error",
+		"no-use-before-define": [ "error", "nofunc" ],
 		"no-useless-call": "error",
 		"no-useless-concat": "error",
 		"no-void": "error",

--- a/test/fixtures/client-es6/invalid.js
+++ b/test/fixtures/client-es6/invalid.js
@@ -1,9 +1,14 @@
 /* eslint-env browser */
 
+// eslint-disable-next-line no-use-before-define
+const c = new MyClass();
+
+class MyClass {}
+
 ( function () {
 	// not-es6
 	// eslint-disable-next-line no-restricted-syntax
-	[].includes();
+	[].includes( c );
 	// eslint-disable-next-line es/no-object-entries
 	Object.entries();
 	// eslint-disable-next-line es/no-object-getownpropertydescriptors

--- a/test/fixtures/common/invalid.js
+++ b/test/fixtures/common/invalid.js
@@ -2,6 +2,9 @@
 var APP;
 // eslint-disable-next-line wrap-iife
 ( function ( global ) {
+	// eslint-disable-next-line no-use-before-define
+	APP = {};
+
 	// eslint-disable-next-line no-shadow
 	var APP;
 	var upHere = function ( yArg ) {
@@ -48,9 +51,6 @@ var APP;
 			// eslint-disable-next-line block-spacing, brace-style, camelcase
 			return camel_case;}
 
-		// eslint-disable-next-line no-use-before-define
-		upHere( i );
-
 		var i;
 		// eslint-disable-next-line max-statements-per-line
 		if ( name ) { return i; }
@@ -69,7 +69,6 @@ var APP;
 		} else if ( options['default' ] ) {
 		// eslint-disable-next-line no-unsafe-negation, keyword-spacing
 		}else if ( !'default' in options ) {
-			// eslint-disable-next-line no-use-before-define
 			name += named();
 		}
 

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -13,6 +13,9 @@
 	// Example
 	/* Example */
 
+	// Valid: no-use-before-define (nofunc)
+	upHere( 1 );
+
 	// Empty function declaration
 	function upHere() {}
 


### PR DESCRIPTION
Keep it enabled for variables and classes

Fixes #434
