### PR TITLE
vue: Update for new rules in eslint-plugin-vue 8.4.1

### DIFF
--- a/test/fixtures/mediawiki/invalid.vue
+++ b/test/fixtures/mediawiki/invalid.vue
@@ -4,7 +4,7 @@
 		<a v-bind:href="foo">Foo</a>
 		<!-- eslint-disable-next-line vue/v-on-style -->
 		<a v-on:click="onClick">Click me</a>
-		<!-- eslint-disable-next-line vue/no-unregistered-components -->
+		<!-- eslint-disable-next-line vue/no-undef-components -->
 		<foo-component>
 			<!-- eslint-disable-next-line vue/v-slot-style -->
 			<template v-slot:default>

--- a/test/fixtures/vue-wrappers/invalid.vue
+++ b/test/fixtures/vue-wrappers/invalid.vue
@@ -11,8 +11,8 @@
 			bar" />
 		<!-- eslint-disable-next-line vue/dot-notation -->
 		<a :href="foo['bar']" />
-		<!-- eslint-disable vue/comma-style, vue/first-attribute-linebreak -->
-		<a :class="{ foo: 'bar'
+		<!-- eslint-disable vue/comma-style, vue/first-attribute-linebreak, vue/quote-props -->
+		<a :class="{ 'foo': 'bar'
 			, baz: 'quux' }" />
 		<!-- eslint-disable-next-line max-len -->
 		<!-- eslint-disable-next-line vue/block-spacing, vue/keyword-spacing, vue/space-in-parens, vue/func-call-spacing -->

--- a/test/fixtures/vue-wrappers/valid.vue
+++ b/test/fixtures/vue-wrappers/valid.vue
@@ -5,6 +5,7 @@
 		<div :class="[ foo, bar ]" />
 		<!-- Valid: vue/key-spacing -->
 		<!-- Valid: vue/object-curly-spacing -->
+		<!-- Valid: vue/quote-props -->
 		<a :class="{ foo: 'bar' }" />
 		<!-- Valid: vue/eqeqeq -->
 		<a :class="foo === 4 ? 8 : 15" />

--- a/test/fixtures/vue2-common/invalid.vue
+++ b/test/fixtures/vue2-common/invalid.vue
@@ -17,8 +17,10 @@
 				{{ baz }}
 			</template>
 		</BlahComponent>
-		<!-- eslint-disable-next-line vue/no-unregistered-components -->
-		<foo-component />
+		<!-- eslint-disable-next-line vue/no-undef-components, vue/no-v-text, vue/no-v-text-v-html-on-component -->
+		<foo-component v-text="foo" />
+		<!-- eslint-disable-next-line vue/no-undef-components, vue/no-v-html, vue/no-v-text-v-html-on-component -->
+		<foo-component v-html="foo" />
 		<!-- eslint-disable-next-line vue/no-static-inline-styles -->
 		<span style="color: red">Red</span>
 		<!-- eslint-disable-next-line vue/no-unused-refs, vue/v-on-function-call -->

--- a/test/fixtures/vue2-common/valid.vue
+++ b/test/fixtures/vue2-common/valid.vue
@@ -14,6 +14,7 @@
 		<!-- Valid: vue/v-on-function-call -->
 		<a @click="foo">Click me</a>
 		<!-- Valid: vue/component-name-in-template-casing -->
+		<!-- Valid: vue/no-v-text-v-html-on-component -->
 		<BlahComponent />
 		<!-- Valid: vue/no-child-content -->
 		<!--

--- a/vue-common.json
+++ b/vue-common.json
@@ -28,7 +28,7 @@
 			} ],
 			"vue/no-static-inline-styles": "error",
 			"vue/no-undef-properties": "error",
-			"vue/no-unregistered-components": "error",
+			"vue/no-undef-components": "error",
 			"vue/no-unsupported-features": [ "error", {
 				"version": "2.6.11"
 			} ],
@@ -76,7 +76,8 @@
 			"vue/component-name-in-template-casing": [ "error", "PascalCase" ],
 			"vue/no-child-content": "error",
 			"vue/no-expose-after-await": "error",
-			"vue/prefer-separate-static-class": "error"
+			"vue/prefer-separate-static-class": "error",
+			"vue/no-v-text-v-html-on-component": "error"
 		}
 	} ]
 }

--- a/vue-wrappers.js
+++ b/vue-wrappers.js
@@ -35,8 +35,10 @@ const rulesToMap = [
 	'object-curly-newline',
 	'object-curly-spacing',
 	'object-property-newline',
+	// object-shorthand is not set by our rules (yet?), add it if/when it is
 	'operator-linebreak',
 	'prefer-template',
+	'quote-props',
 	'sort-keys',
 	'space-infix-ops',
 	'space-in-parens',


### PR DESCRIPTION
- Use no-undef-components instead of deprecated
  no-unregistered-components
- Add no-v-text-v-html-on-component
- Add quote-props to wrappers

A wrapper for object-shorthand was also added, but we don't set that
rule in our ruleset.