### PR TITLE
common: Add stylelint- comments to max-len ignorePattern

### DIFF
--- a/common.json
+++ b/common.json
@@ -43,7 +43,7 @@
 		"max-len": [ "warn", {
 			"code": 100,
 			"tabWidth": 4,
-			"ignorePattern": "^[\\s]*(//|<!--) eslint-.+",
+			"ignorePattern": "^[\\s]*(//|<!--) (es|style)lint-.+",
 			"ignoreUrls": true,
 			"ignoreComments": false,
 			"ignoreRegExpLiterals": true,

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -48,6 +48,7 @@
 
 		// Valid: max-len
 		// eslint-comments-starting-with-"eslint-"-are-allowed-to-be-any-length---------------------------
+		// stylelint-comments-starting-with-"stylelint-"-are-also-allowed-to-be-any-length---------------------------
 
 		// Valid: space-infix-ops
 		this.total = upHere() + id;


### PR DESCRIPTION
Lines with // eslint-disable comments are already ignored.
However, in .vue files, ESLint runs the max-len rule against
the <style> block too for some reason, so it complains about
line lengths for stylelint-disable comments.

Add stylelint- to the regex for disabling max-len, so that we don't
complain about stylelint-disable comments being too long.