### PR TITLE
jsdoc: Update eslint-plugin-jsdoc to 38.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"eslint": "^8.6.0",
 				"eslint-plugin-compat": "^4.0.2",
 				"eslint-plugin-es": "^4.1.0",
-				"eslint-plugin-jsdoc": "^37.7.1",
+				"eslint-plugin-jsdoc": "^38.1.6",
 				"eslint-plugin-json-es": "^1.5.7",
 				"eslint-plugin-mediawiki": "^0.3.0",
 				"eslint-plugin-mocha": "^9.0.0",
@@ -127,13 +127,13 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
-			"integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
+			"version": "0.22.2",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
+			"integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
 			"dependencies": {
-				"comment-parser": "1.3.0",
+				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.2"
+				"jsdoc-type-pratt-parser": "~2.2.5"
 			},
 			"engines": {
 				"node": "^12 || ^14 || ^16 || ^17"
@@ -397,9 +397,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-			"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
 			"engines": {
 				"node": ">= 12.0.0"
 			}
@@ -433,9 +433,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -606,13 +606,13 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "37.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.1.tgz",
-			"integrity": "sha512-ySxDTedl6qKXT/VeTwcZlhsRtvNQZGPklyVnaL5+ge20vowzFA9CKvrY0NXRqvdIz6JBVMFpxX9DSmS3OyAUOQ==",
+			"version": "38.1.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
+			"integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.18.0",
-				"comment-parser": "1.3.0",
-				"debug": "^4.3.3",
+				"@es-joy/jsdoccomment": "~0.22.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
 				"regextras": "^0.8.0",
@@ -624,6 +624,20 @@
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-plugin-json-es": {
@@ -1413,9 +1427,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
-			"integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
+			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -2274,13 +2288,13 @@
 			}
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
-			"integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
+			"version": "0.22.2",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
+			"integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
 			"requires": {
-				"comment-parser": "1.3.0",
+				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.2"
+				"jsdoc-type-pratt-parser": "~2.2.5"
 			}
 		},
 		"@eslint/eslintrc": {
@@ -2472,9 +2486,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-			"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2497,9 +2511,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -2661,18 +2675,28 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "37.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.1.tgz",
-			"integrity": "sha512-ySxDTedl6qKXT/VeTwcZlhsRtvNQZGPklyVnaL5+ge20vowzFA9CKvrY0NXRqvdIz6JBVMFpxX9DSmS3OyAUOQ==",
+			"version": "38.1.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
+			"integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.18.0",
-				"comment-parser": "1.3.0",
-				"debug": "^4.3.3",
+				"@es-joy/jsdoccomment": "~0.22.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
 				"regextras": "^0.8.0",
 				"semver": "^7.3.5",
 				"spdx-expression-parse": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"eslint-plugin-json-es": {
@@ -3197,9 +3221,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
-			"integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw=="
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
+			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw=="
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"eslint": "^8.6.0",
 		"eslint-plugin-compat": "^4.0.2",
 		"eslint-plugin-es": "^4.1.0",
-		"eslint-plugin-jsdoc": "^37.7.1",
+		"eslint-plugin-jsdoc": "^38.1.6",
 		"eslint-plugin-json-es": "^1.5.7",
 		"eslint-plugin-mediawiki": "^0.3.0",
 		"eslint-plugin-mocha": "^9.0.0",

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -22,6 +22,7 @@
 
 	// Valid: settings.jsdoc.tagNamePreference
 	// Off: jsdoc/tag-lines
+	// Off: jsdoc/sort-tags
 	/**
 	 * Non-default aliases:
 	 *


### PR DESCRIPTION
This is the last update we can do before dropping Node 12.
