### PR TITLE
vue: Use Vue 3 by default

### DIFF
--- a/client-es6.json
+++ b/client-es6.json
@@ -2,6 +2,6 @@
 	"extends": [
 		"./client-common",
 		"./language/es6",
-		"./vue3-es6"
+		"./vue-es6"
 	]
 }

--- a/client-es6.json
+++ b/client-es6.json
@@ -2,6 +2,6 @@
 	"extends": [
 		"./client-common",
 		"./language/es6",
-		"./vue2-es6"
+		"./vue3-es6"
 	]
 }

--- a/vue-es6.json
+++ b/vue-es6.json
@@ -1,3 +1,3 @@
 {
-	"extends": "./vue2-es6"
+	"extends": "./vue3-es6"
 }


### PR DESCRIPTION
This changes the client-es6 and vue-es6 rule sets to use vue3-es6
instead of vue2-es6, making Vue 3 the default for ES6 code.

ES6 code needing to use Vue 2 rules can manually combine the
wikimedia/client-common and wikimedia/vue2-es6 rules.

ES5 code still uses Vue 2 rules. We don't have a vue3-es5 rule set,
because Vue 3 requires ES6. Code targeting Vue 3 should use the ES6
rules.