### PR TITLE
mediawiki: Upgrade eslint-plugin-mediawiki to v0.4.0

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -19,6 +19,8 @@ const config = {
 	"rules": {
 		"mediawiki/class-doc": "error",
 		"mediawiki/msg-doc": "error",
+		"mediawiki/no-extended-unicode-identifiers": "error",
+		"mediawiki/no-nodelist-unsupported-methods": "error",
 		"mediawiki/valid-package-file-require": "error",
 		"compat/compat": [
 			"error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"eslint-plugin-es-x": "^5.2.1",
 				"eslint-plugin-jsdoc": "^38.1.6",
 				"eslint-plugin-json-es": "^1.5.7",
-				"eslint-plugin-mediawiki": "^0.3.0",
+				"eslint-plugin-mediawiki": "^0.4.0",
 				"eslint-plugin-mocha": "^9.0.0",
 				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-node": "^11.1.0",
@@ -190,6 +190,7 @@
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -655,84 +656,15 @@
 			}
 		},
 		"node_modules/eslint-plugin-mediawiki": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.3.0.tgz",
-			"integrity": "sha512-Lhyj2PSkhDzYSc1PNbURysY/WoqvY0brw558ZInT3erzf5KUlro18MTKFdV+nlht475ZgnsfHsgfg6Ut2w1SVg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.4.0.tgz",
+			"integrity": "sha512-Eufptb8lrElYwIONvgxlMBnPD6PYT4xAFprWlBxV5brCmUh8MZ41+lMxt2TPwEC6C85ngflkVez8BV8tWS9RyQ==",
 			"dependencies": {
-				"eslint-plugin-vue": "^7.20.0",
+				"eslint-plugin-vue": "^8.7.1",
 				"upath": "^2.0.1"
 			},
 			"peerDependencies": {
 				"eslint": ">=5.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-mediawiki/node_modules/eslint-plugin-vue": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.20.0.tgz",
-			"integrity": "sha512-oVNDqzBC9h3GO+NTgWeLMhhGigy6/bQaQbHS+0z7C4YEu/qK/yxHvca/2PTZtGNPsCrHwOTgKMrwu02A9iPBmw==",
-			"dependencies": {
-				"eslint-utils": "^2.1.0",
-				"natural-compare": "^1.4.0",
-				"semver": "^6.3.0",
-				"vue-eslint-parser": "^7.10.0"
-			},
-			"engines": {
-				"node": ">=8.10"
-			},
-			"peerDependencies": {
-				"eslint": "^6.2.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-mediawiki/node_modules/eslint-plugin-vue/node_modules/vue-eslint-parser": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
-			"integrity": "sha512-qh3VhDLeh773wjgNTl7ss0VejY9bMMa0GoDG2fQVyDzRFdiU3L7fw74tWZDHNQXdZqxO3EveQroa9ct39D2nqg==",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"eslint-scope": "^5.1.1",
-				"eslint-visitor-keys": "^1.1.0",
-				"espree": "^6.2.1",
-				"esquery": "^1.4.0",
-				"lodash": "^4.17.21",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-mediawiki/node_modules/eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-plugin-mediawiki/node_modules/espree": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-			"dependencies": {
-				"acorn": "^7.1.1",
-				"acorn-jsx": "^5.2.0",
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-mediawiki/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-plugin-mocha": {
@@ -960,18 +892,6 @@
 				"eslint": ">=6.0.0"
 			}
 		},
-		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/eslint-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -1121,14 +1041,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -2349,7 +2261,8 @@
 		"acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"peer": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -2718,61 +2631,12 @@
 			}
 		},
 		"eslint-plugin-mediawiki": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.3.0.tgz",
-			"integrity": "sha512-Lhyj2PSkhDzYSc1PNbURysY/WoqvY0brw558ZInT3erzf5KUlro18MTKFdV+nlht475ZgnsfHsgfg6Ut2w1SVg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.4.0.tgz",
+			"integrity": "sha512-Eufptb8lrElYwIONvgxlMBnPD6PYT4xAFprWlBxV5brCmUh8MZ41+lMxt2TPwEC6C85ngflkVez8BV8tWS9RyQ==",
 			"requires": {
-				"eslint-plugin-vue": "^7.20.0",
+				"eslint-plugin-vue": "^8.7.1",
 				"upath": "^2.0.1"
-			},
-			"dependencies": {
-				"eslint-plugin-vue": {
-					"version": "7.20.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.20.0.tgz",
-					"integrity": "sha512-oVNDqzBC9h3GO+NTgWeLMhhGigy6/bQaQbHS+0z7C4YEu/qK/yxHvca/2PTZtGNPsCrHwOTgKMrwu02A9iPBmw==",
-					"requires": {
-						"eslint-utils": "^2.1.0",
-						"natural-compare": "^1.4.0",
-						"semver": "^6.3.0",
-						"vue-eslint-parser": "^7.10.0"
-					},
-					"dependencies": {
-						"vue-eslint-parser": {
-							"version": "7.11.0",
-							"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
-							"integrity": "sha512-qh3VhDLeh773wjgNTl7ss0VejY9bMMa0GoDG2fQVyDzRFdiU3L7fw74tWZDHNQXdZqxO3EveQroa9ct39D2nqg==",
-							"requires": {
-								"debug": "^4.1.1",
-								"eslint-scope": "^5.1.1",
-								"eslint-visitor-keys": "^1.1.0",
-								"espree": "^6.2.1",
-								"esquery": "^1.4.0",
-								"lodash": "^4.17.21",
-								"semver": "^6.3.0"
-							}
-						}
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
-				},
-				"espree": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-					"requires": {
-						"acorn": "^7.1.1",
-						"acorn-jsx": "^5.2.0",
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"eslint-plugin-mocha": {
@@ -2918,15 +2782,6 @@
 				"yaml-eslint-parser": "^0.5.0"
 			}
 		},
-		"eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"requires": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			}
-		},
 		"eslint-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -2998,11 +2853,6 @@
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
 				}
 			}
-		},
-		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
 		"esutils": {
 			"version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 			},
 			"devDependencies": {
 				"escape-string-regexp": "^4.0.0",
+				"fs-readdir-recursive": "^1.1.0",
 				"qunit": "^2.18.2"
 			}
 		},
@@ -1110,6 +1111,12 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
 			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+		},
+		"node_modules/fs-readdir-recursive": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -2904,6 +2911,12 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
 			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+		},
+		"fs-readdir-recursive": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 	},
 	"devDependencies": {
 		"escape-string-regexp": "^4.0.0",
+		"fs-readdir-recursive": "^1.1.0",
 		"qunit": "^2.18.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"eslint-plugin-es-x": "^5.2.1",
 		"eslint-plugin-jsdoc": "^38.1.6",
 		"eslint-plugin-json-es": "^1.5.7",
-		"eslint-plugin-mediawiki": "^0.3.0",
+		"eslint-plugin-mediawiki": "^0.4.0",
 		"eslint-plugin-mocha": "^9.0.0",
 		"eslint-plugin-no-jquery": "^2.7.0",
 		"eslint-plugin-node": "^11.1.0",

--- a/test/fixtures/mediawiki/es6/.eslintrc.json
+++ b/test/fixtures/mediawiki/es6/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"root": true,
+	"extends": [
+		"../../../../client-es6",
+		"../../../../mediawiki"
+	]
+}

--- a/test/fixtures/mediawiki/es6/invalid.js
+++ b/test/fixtures/mediawiki/es6/invalid.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-unused-vars */
+( function () {
+	// eslint-disable-next-line mediawiki/no-extended-unicode-identifiers
+	const 𐋀 = 13;
+}() );

--- a/test/fixtures/mediawiki/invalid.js
+++ b/test/fixtures/mediawiki/invalid.js
@@ -13,6 +13,12 @@
 	// eslint-disable-next-line mediawiki/valid-package-file-require
 	require( 'valid.js' );
 
+	// The following triggers a parser error in eslint
+	// <!-- eslint-disable-next-line mediawiki/no-extended-unicode-identifiers -- >
+
+	// eslint-disable-next-line mediawiki/no-nodelist-unsupported-methods
+	document.querySelectorAll( '.foo' ).forEach();
+
 	// eslint-disable-next-line compat/compat
 	bar = navigator.permissions.query();
 

--- a/test/fixtures/mediawiki/invalid.js
+++ b/test/fixtures/mediawiki/invalid.js
@@ -13,9 +13,6 @@
 	// eslint-disable-next-line mediawiki/valid-package-file-require
 	require( 'valid.js' );
 
-	// The following triggers a parser error in eslint
-	// <!-- eslint-disable-next-line mediawiki/no-extended-unicode-identifiers -- >
-
 	// eslint-disable-next-line mediawiki/no-nodelist-unsupported-methods
 	document.querySelectorAll( '.foo' ).forEach();
 

--- a/test/fixtures/mediawiki/valid.js
+++ b/test/fixtures/mediawiki/valid.js
@@ -10,6 +10,9 @@
 	// * foo-bar2
 	document.body.classList.add( 'foo-' + bar );
 
+	// Valid: mediawiki/no-extended-unicode-identifiers
+	var α = 13;
+
 	// Global: mw
 	// Valid: mediawiki/msg-doc
 	// The following messages are used here:
@@ -17,13 +20,16 @@
 	// * foo-bar2
 	// * extension-reallylongextensionname-dialog-subfeature-process-myoptionwidget-pending-modifier-label-3
 	//   * extension-reallylongextensionname-dialog-subfeature-process-myoptionwidget-pending-modifier-label-3b
-	mw.msg( 'foo-' + bar );
+	mw.msg( 'foo-' + bar + α );
 
 	// Global: require
 	// Valid: mediawiki/valid-package-file-require
 	require( './invalid.js' );
 	require( './../test.js' );
 	require( 'SomePackage' );
+
+	// Valid: mediawiki/no-nodelist-unsupported-methods
+	[].forEach();
 }() );
 
 // Global: module

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ const fs = require( 'fs' ),
 	path = require( 'path' ),
 	configs = require( '../package' ).files,
 	escapeStringRegexp = require( 'escape-string-regexp' ),
+	readdirRecursive = require( 'fs-readdir-recursive' ),
 	{ ESLint } = require( 'eslint' ),
 	eslint = new ESLint();
 
@@ -120,7 +121,7 @@ configs.forEach( ( configPath ) => {
 
 		const config = require( `../${configPath}` );
 
-		const fixturesFiles = fs.readdirSync( fixturesDir )
+		const fixturesFiles = readdirRecursive( fixturesDir )
 			.map( ( file ) => path.resolve( fixturesDir, file ) );
 
 		const validFixturesFiles = fixturesFiles.filter( ( file ) => file.includes( '/valid' ) );


### PR DESCRIPTION
* New rule: `no-nodelist-unsupported-methods` (Ed Sanders)
* New rule: `no-extended-unicode-identifiers` (Roan Kattouw)
* Rule fix: `msg-doc`: Fix short URL to rule help page (Sam Wilson)
* Rule fix: `class-doc`: Fix linting of classList.toggle (Ed Sanders)