### PR TITLE
mediawiki: Add "exports" global

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -9,7 +9,8 @@ const config = {
 		"mw": "readonly",
 		"OO": "readonly",
 		"require": "readonly",
-		"module": "readonly"
+		"module": "readonly",
+		"exports": "writable"
 	},
 	"plugins": [
 		"mediawiki",

--- a/test/fixtures/mediawiki/valid.js
+++ b/test/fixtures/mediawiki/valid.js
@@ -27,4 +27,5 @@
 }() );
 
 // Global: module
-module.exports = {};
+// Global: exports
+module.exports = exports = {};


### PR DESCRIPTION
Support for setting exports = foo; as an alias for module.exports = foo;
was added by https://phabricator.wikimedia.org/T284511.

Per https://phabricator.wikimedia.org/T302831, using
module.exports = exports = ...; is required in .vue files to make the
Jest unit tests work. Because the "exports" global was not provided by
the mediawiki ruleset, every repo migrating their Vue tests has been
adding it to their eslint config separately.