### PR TITLE
Disable es-x/no-symbol-prototype-description

### DIFF
--- a/language/es2016.json
+++ b/language/es2016.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es2016",
 		"plugin:es-x/restrict-to-es2016",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es2016"
 	],
 	"parserOptions": {
 		"ecmaVersion": 2016

--- a/language/es2017.json
+++ b/language/es2017.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es2017",
 		"plugin:es-x/restrict-to-es2017",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es2017"
 	],
 	"parserOptions": {
 		"ecmaVersion": 2017

--- a/language/es2018.json
+++ b/language/es2018.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es2018",
 		"plugin:es-x/restrict-to-es2018",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es2018"
 	],
 	"parserOptions": {
 		"ecmaVersion": 2018

--- a/language/es2019.json
+++ b/language/es2019.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es2019",
 		"plugin:es-x/restrict-to-es2019",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es2019"
 	],
 	"parserOptions": {
 		"ecmaVersion": 2019

--- a/language/es2020.json
+++ b/language/es2020.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es2020",
 		"plugin:es-x/restrict-to-es2020",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es2020"
 	],
 	"parserOptions": {
 		"ecmaVersion": 2020

--- a/language/es2021.json
+++ b/language/es2021.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es2021",
 		"plugin:es-x/restrict-to-es2021",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es2021"
 	],
 	"parserOptions": {
 		"ecmaVersion": 2021

--- a/language/es2022.json
+++ b/language/es2022.json
@@ -1,8 +1,8 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es2022",
-		"plugin:es-x/restrict-to-es2022"
+		"plugin:es-x/restrict-to-es2022",
+		"./rules-es2022"
 	],
 	"parserOptions": {
 		"ecmaVersion": 2022

--- a/language/es5.json
+++ b/language/es5.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es5",
 		"plugin:es-x/restrict-to-es5",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es5"
 	],
 	"parserOptions": {
 		"ecmaVersion": 5

--- a/language/es6.json
+++ b/language/es6.json
@@ -1,9 +1,9 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"./rules-es6",
 		"plugin:es-x/restrict-to-es2015",
-		"plugin:es-x/no-new-in-esnext"
+		"plugin:es-x/no-new-in-esnext",
+		"./rules-es6"
 	],
 	"parserOptions": {
 		"ecmaVersion": 6

--- a/language/rules-es5.json
+++ b/language/rules-es5.json
@@ -1,1 +1,5 @@
-{}
+{
+	"rules": {
+		"es-x/no-symbol-prototype-description": "off"
+	}
+}

--- a/test/fixtures/client-es5/valid.js
+++ b/test/fixtures/client-es5/valid.js
@@ -3,5 +3,11 @@
 	var $div;
 	// [].find should be disabled, but it conflicts with jQuery
 	// Off: es-x/no-array-prototype-find
-	$div.find();
+	$div.find(
+		// Symbol.prototype.descrition is disabled, but conflicts
+		// with many plain object properties.
+		// Off: es-x/no-symbol-prototype-description
+		$div.description
+	);
+
 }() );

--- a/test/fixtures/client-es6/valid.js
+++ b/test/fixtures/client-es6/valid.js
@@ -79,4 +79,9 @@
 	// Valid: es-x/no-string-raw
 	String.raw();
 
+	// Symbol.prototype.descrition is disabled, but conflicts
+	// with many plain object properties.
+	// Off: es-x/no-symbol-prototype-description
+	// eslint-disable-next-line no-unused-expressions
+	node.description;
 }() );

--- a/test/fixtures/server/valid.js
+++ b/test/fixtures/server/valid.js
@@ -47,4 +47,11 @@
 
 	// Off: node/no-extraneous-require
 
+	// ES 019
+	// Symbol.prototype.descrition is disabled, but conflicts
+	// with many plain object properties.
+	// Off: es-x/no-symbol-prototype-description
+	// eslint-disable-next-line no-unused-expressions
+	a.description;
+
 }( this ) );


### PR DESCRIPTION
Also fix inheritance order so rule is not re-enabled
when loading newer versions of ES.

Part of #477
