### PR TITLE
Language: Remove reference to non-existent "restrict-to-es2022"

### DIFF
--- a/language/es2022.json
+++ b/language/es2022.json
@@ -1,7 +1,6 @@
 {
 	"plugins": [ "es-x" ],
 	"extends": [
-		"plugin:es-x/restrict-to-es2022",
 		"./rules-es2022"
 	],
 	"parserOptions": {


### PR DESCRIPTION
Fixes #479
