### PR TITLE
upgrade "eslint-plugin-jsdoc" to 39.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"eslint": "^8.14.0",
 				"eslint-plugin-compat": "^4.0.2",
 				"eslint-plugin-es-x": "^5.2.1",
-				"eslint-plugin-jsdoc": "^38.1.6",
+				"eslint-plugin-jsdoc": "^39.6.4",
 				"eslint-plugin-json-es": "^1.5.7",
 				"eslint-plugin-mediawiki": "^0.4.0",
 				"eslint-plugin-mocha": "^9.0.0",
@@ -128,16 +128,16 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
-			"integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"dependencies": {
 				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.5"
+				"jsdoc-type-pratt-parser": "~3.1.0"
 			},
 			"engines": {
-				"node": "^12 || ^14 || ^16 || ^17"
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -602,30 +602,29 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "38.1.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
-			"integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
+			"version": "39.6.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+			"integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.22.1",
+				"@es-joy/jsdoccomment": "~0.36.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"regextras": "^0.8.0",
-				"semver": "^7.3.5",
+				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"engines": {
-				"node": "^12 || ^14 || ^16 || ^17"
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -1334,9 +1333,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -1422,9 +1421,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1777,14 +1776,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/regextras": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
-			"engines": {
-				"node": ">=0.1.14"
 			}
 		},
 		"node_modules/requireindex": {
@@ -2215,13 +2206,13 @@
 			}
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
-			"integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"requires": {
 				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.5"
+				"jsdoc-type-pratt-parser": "~3.1.0"
 			}
 		},
 		"@eslint/eslintrc": {
@@ -2597,24 +2588,23 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "38.1.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
-			"integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
+			"version": "39.6.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+			"integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.22.1",
+				"@es-joy/jsdoccomment": "~0.36.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"regextras": "^0.8.0",
-				"semver": "^7.3.5",
+				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -3083,9 +3073,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw=="
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -3153,9 +3143,9 @@
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -3410,11 +3400,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
-		},
-		"regextras": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ=="
 		},
 		"requireindex": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"eslint": "^8.14.0",
 		"eslint-plugin-compat": "^4.0.2",
 		"eslint-plugin-es-x": "^5.2.1",
-		"eslint-plugin-jsdoc": "^38.1.6",
+		"eslint-plugin-jsdoc": "^39.6.4",
 		"eslint-plugin-json-es": "^1.5.7",
 		"eslint-plugin-mediawiki": "^0.4.0",
 		"eslint-plugin-mocha": "^9.0.0",


### PR DESCRIPTION
The overall package does not support Node 18/19 because of the outdated version of the "eslint-plugin-jsdoc" dependency. This upgrades the version.