### PR TITLE
build: Ensure eslint-plugin-qunit 7.3.0 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"eslint-plugin-mocha": "^9.0.0",
 				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-qunit": "^7.2.0",
+				"eslint-plugin-qunit": "^7.3.0",
 				"eslint-plugin-unicorn": "^42.0.0",
 				"eslint-plugin-vue": "^8.7.1",
 				"eslint-plugin-wdio": "^7.19.4",
@@ -809,9 +809,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-qunit": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
-			"integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.3.4.tgz",
+			"integrity": "sha512-EbDM0zJerH9zVdUswMJpcFF7wrrpvsGuYfNexUpa5hZkkdFhaFcX+yD+RSK4Nrauw4psMGlcqeWUMhaVo+Manw==",
 			"dependencies": {
 				"eslint-utils": "^3.0.0",
 				"requireindex": "^1.2.0"
@@ -2840,9 +2840,9 @@
 			}
 		},
 		"eslint-plugin-qunit": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
-			"integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.3.4.tgz",
+			"integrity": "sha512-EbDM0zJerH9zVdUswMJpcFF7wrrpvsGuYfNexUpa5hZkkdFhaFcX+yD+RSK4Nrauw4psMGlcqeWUMhaVo+Manw==",
 			"requires": {
 				"eslint-utils": "^3.0.0",
 				"requireindex": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"eslint-plugin-mocha": "^9.0.0",
 		"eslint-plugin-no-jquery": "^2.7.0",
 		"eslint-plugin-node": "^11.1.0",
-		"eslint-plugin-qunit": "^7.2.0",
+		"eslint-plugin-qunit": "^7.3.0",
 		"eslint-plugin-unicorn": "^42.0.0",
 		"eslint-plugin-vue": "^8.7.1",
 		"eslint-plugin-wdio": "^7.19.4",


### PR DESCRIPTION
The bug fix at https://github.com/platinumazure/eslint-plugin-qunit/pull/231 was released in March 2022 as part of 7.3.0.

Fresh installs of eslint-config-wikimedia already expand `^7.2.0` to 7.3.4, but I'd rather set a minimum so that the next propagation of eslint-config-wikimedia will naturally update this, because otherwise npm is conservative nowadays and only updates when forced to or when doing a full rebuild after deleting one's lock file.