### PR TITLE
client: Change default from ES5 to ES6

### DIFF
--- a/client.json
+++ b/client.json
@@ -1,5 +1,5 @@
 {
 	"extends": [
-		"./client-es5"
+		"./client-es6"
 	]
 }


### PR DESCRIPTION
This change matches that for MediaWiki 1.41. Code that explicitly wishes to support ES5 clients still can extend wikimedia/client-es5, as has been recommended for a while.