### PR TITLE
mediawiki: Use only ES6 browsers for compat/compat

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const commonRules = require( './common' );
-const browsers = require( 'browserslist-config-wikimedia/modern' );
+const browsers = require( 'browserslist-config-wikimedia/modern-es6-only' );
 
 /* eslint-disable quote-props, quotes */
 const config = {


### PR DESCRIPTION
MediaWiki no longer supports non-ES6 browsers, so stop raising compat warnings for browsers like IE11