### PR TITLE
mediawiki: Upgrade eslint-plugin-mediawiki to v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"eslint-plugin-es-x": "^5.2.1",
 				"eslint-plugin-jsdoc": "39.2.2",
 				"eslint-plugin-json-es": "^1.5.7",
-				"eslint-plugin-mediawiki": "^0.4.0",
+				"eslint-plugin-mediawiki": "^0.5.0",
 				"eslint-plugin-mocha": "^9.0.0",
 				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-node": "^11.1.0",
@@ -712,9 +712,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-mediawiki": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.4.0.tgz",
-			"integrity": "sha512-Eufptb8lrElYwIONvgxlMBnPD6PYT4xAFprWlBxV5brCmUh8MZ41+lMxt2TPwEC6C85ngflkVez8BV8tWS9RyQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.5.0.tgz",
+			"integrity": "sha512-rjkHFyv3VDan/dmu7YpD1Rl9h64NOlz4mqqesRN316R+571+ymmb6lXVOdNMbT8H1iPhmtHc+nijVLVkn7pYDw==",
 			"dependencies": {
 				"eslint-plugin-vue": "^8.7.1",
 				"upath": "^2.0.1"
@@ -2777,9 +2777,9 @@
 			}
 		},
 		"eslint-plugin-mediawiki": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.4.0.tgz",
-			"integrity": "sha512-Eufptb8lrElYwIONvgxlMBnPD6PYT4xAFprWlBxV5brCmUh8MZ41+lMxt2TPwEC6C85ngflkVez8BV8tWS9RyQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.5.0.tgz",
+			"integrity": "sha512-rjkHFyv3VDan/dmu7YpD1Rl9h64NOlz4mqqesRN316R+571+ymmb6lXVOdNMbT8H1iPhmtHc+nijVLVkn7pYDw==",
 			"requires": {
 				"eslint-plugin-vue": "^8.7.1",
 				"upath": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"eslint-plugin-es-x": "^5.2.1",
 		"eslint-plugin-jsdoc": "39.2.2",
 		"eslint-plugin-json-es": "^1.5.7",
-		"eslint-plugin-mediawiki": "^0.4.0",
+		"eslint-plugin-mediawiki": "^0.5.0",
 		"eslint-plugin-mocha": "^9.0.0",
 		"eslint-plugin-no-jquery": "^2.7.0",
 		"eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
* Create `common` and `vue` shared configs (Ed Sanders)
* Rule fix: `msg-doc`: Disallow `$i18n` calls with dynamic arguments without documentation (Florent)
* Rule fix: `msg-doc`: Support `new msg.Message()` (Florent)
* Rule fix: `vue-exports-component-directive`: Recognize `defineComponent()` (Roan Kattouw)