### PR TITLE
Revert "mediawiki: Use only ES6 browsers for compat/compat"

### DIFF
--- a/mediawiki.js
+++ b/mediawiki.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const commonRules = require( './common' );
-const browsers = require( 'browserslist-config-wikimedia/modern-es6-only' );
+const browsers = require( 'browserslist-config-wikimedia/modern' );
 
 /* eslint-disable quote-props, quotes */
 const config = {


### PR DESCRIPTION
Reverts wikimedia/eslint-config-wikimedia#493

This should be fixed upstream instead.