### PR TITLE
mediawiki-qunit: new preset (ES2022 async-await in unit tests)

### DIFF
--- a/mediawiki-qunit.json
+++ b/mediawiki-qunit.json
@@ -1,0 +1,18 @@
+{
+	"extends": [
+		"./client-common",
+		"./language/es2022",
+		"./jquery",
+		"./mediawiki",
+		"./qunit"
+	],
+	"globals": {
+		"sinon": "readonly"
+	},
+	"rules": {
+		"compat/compat": [ "error", "last 2 chrome versions, last 2 firefox versions, last 2 safari versions" ],
+		"max-len": "off",
+		"no-jquery/no-global-selector": "off",
+		"no-jquery/no-parse-html-literal": "off"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"jsduck.json",
 		"json.json",
 		"mediawiki.js",
+		"mediawiki-qunit.json",
 		"mocha.json",
 		"qunit.json",
 		"selenium.json",

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,17 @@ You can extend the above config by also adding a second `.eslintrc.json` file in
 ```json
 {
 	"extends": [
-		"../../.eslintrc.json",
+		"wikimedia/mediawiki-qunit"
+	]
+}
+```
+
+Or for standalone JavaScript libraries and Node.js projects:
+
+`tests/.eslintrc.json`:
+```json
+{
+	"extends": [
 		"wikimedia/qunit"
 	]
 }

--- a/test/fixtures/mediawiki-qunit/.eslintrc.json
+++ b/test/fixtures/mediawiki-qunit/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+	"root": true,
+	"extends": [
+		"../../../mediawiki-qunit"
+	]
+}

--- a/test/fixtures/mediawiki-qunit/invalid.js
+++ b/test/fixtures/mediawiki-qunit/invalid.js
@@ -1,0 +1,8 @@
+QUnit.module( 'example' );
+
+QUnit.test( 'test', function ( assert ) {
+	// eslint-disable-next-line compat/compat
+	const data = navigator.getBattery();
+
+	assert.strictEqual( data, 1024 );
+} );

--- a/test/fixtures/mediawiki-qunit/valid.js
+++ b/test/fixtures/mediawiki-qunit/valid.js
@@ -1,0 +1,21 @@
+QUnit.module( 'example', () => {
+
+	QUnit.test( 'test', ( assert ) => {
+		// Off: max-len
+		const data = { url: 'https://en.wikipedia.org/wiki/Cneoridium_dumosum_(Nuttall)_Hooker_F._Collected_March_26,_1960,_at_an_Elevation_of_about_1450_Meters_on_Cerro_Quemaz%C3%B3n,_15_Miles_South_of_Bah%C3%ADa_de_Los_Angeles,_Baja_California,_M%C3%A9xico,_Apparently_for_a_Southeastward_Range_Extension_of_Some_140_Miles', from: 'https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_records' };
+
+		// Off: no-jquery/no-global-selector
+		$( '#example .foo' );
+
+		// Off: no-jquery/no-parse-html-literal
+		$( '<div>contents</div>' );
+
+		// Global: sinon
+		sinon.stub( data, 'isValid', function () {
+			return true;
+		} );
+
+		assert.true( data.save() );
+	} );
+
+} );


### PR DESCRIPTION
This preset bumps the allowed ES syntax for the `/tests/qunit` folder from ES6 to ES2022 to unlock use of **async-await** and other QUnit features that make testing Promises and async code a bit easier. 

Example at: <https://gerrit.wikimedia.org/r/908980/>

-----

The current convention [1] is for repos to place the following in their /tests/qunit/ folder:

```
{
	"root": true,
	"extends": [
		"wikimedia/qunit",
		"../../../.eslintrc.json"
	]
	"globals": {
		"sinon": "readonly"
	},
	"rules": {
		"no-jquery/no-global-selector": "off",
		"no-jquery/no-parse-html-literal": "off"
	}
}
```

or

```
{
	"root": true,
	"extends": [
		"wikimedia/client-es6",
		"wikimedia/jquery",
		"wikimedia/mediawiki",
		"wikimedia/qunit"
	]
	"globals": {
		"sinon": "readonly"
	},
	"rules": {
		"no-jquery/no-global-selector": "off",
		"no-jquery/no-parse-html-literal": "off"
	}
}
```

This preset adopts these conventions as a built-in preset.

I think it's an important criteria to meet, when naming a preset
in a generic way like this (without number) is that its requirements
follow from truly "instant" centralised placement. I believe the
answer is yes in these cases, or in enough cases that a preset
is worth having that if we find edge cases that don't, they can continue
to define their config the way they do today.

* It is not possible for an extension to register its QUnit
  tests such that it doesn't have `sinon` or `mw` available.
* The versions of browsers we run CI cannot currently vary
  by extension. Similarly, local dev environments generally
  include recent browsers (e.g. fresh-node).
* The desire to warn against certain needless use of jQuery applies
  to tests the same way it applies to prod code. Perhaps less urgent
  but doesn't hurt.
* The desire to disable no-jquery rules for testing purposes
  (convenient parsing and selecting) is widespread [1] and harmless
  either way as tests ensure that it works, and it doesn't affect
  performance of production.

[1] https://codesearch.wmcloud.org/search/?q=wikimedia%2Fqunit&files=eslint