### PR TITLE
Update eslint-plugin-compat to 4.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"browserslist-config-wikimedia": "^0.5.0",
 				"eslint": "^8.31.0",
-				"eslint-plugin-compat": "^4.0.2",
+				"eslint-plugin-compat": "^4.1.4",
 				"eslint-plugin-es-x": "^5.2.1",
 				"eslint-plugin-jsdoc": "39.2.2",
 				"eslint-plugin-json-es": "^1.5.7",
@@ -194,9 +194,9 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
 		},
 		"node_modules/@mdn/browser-compat-data": {
-			"version": "3.3.14",
-			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
-			"integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA=="
+			"version": "5.2.59",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.59.tgz",
+			"integrity": "sha512-f7VxPGqVLCSe+0KdDas33JyGY+eHJTfBkgAsoiM1BSv7e238FYJMTFwfGLhjnhOwc33wUwsnjiHSfXukwzbqog=="
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -229,6 +229,11 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -297,11 +302,11 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/ast-metadata-inferer": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
-			"integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.0.tgz",
+			"integrity": "sha512-jOMKcHht9LxYIEQu+RVd22vtgrPaVCtDRQ/16IGmurdzxvYbDd5ynxjnyrzLnieG96eTcAyaoj/wN/4/1FyyeA==",
 			"dependencies": {
-				"@mdn/browser-compat-data": "^3.3.14"
+				"@mdn/browser-compat-data": "^5.2.34"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -324,25 +329,30 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.5.tgz",
-			"integrity": "sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==",
+			"version": "4.21.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001271",
-				"electron-to-chromium": "^1.3.878",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001449",
+				"electron-to-chromium": "^1.4.284",
+				"node-releases": "^2.0.8",
+				"update-browserslist-db": "^1.0.10"
 			},
 			"bin": {
 				"browserslist": "cli.js"
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
 			}
 		},
 		"node_modules/browserslist-config-wikimedia": {
@@ -370,9 +380,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001442",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-			"integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+			"version": "1.0.30001488",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+			"integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -381,6 +391,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
 		},
@@ -461,16 +475,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
-		"node_modules/core-js": {
-			"version": "3.20.2",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-			"integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==",
-			"hasInstallScript": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -528,9 +532,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.881",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.881.tgz",
-			"integrity": "sha512-XoAaO4CXk7FXtF2JH0PJ7KgHL1PyZ76G+NhuL337pMiOGlEWwTTSzMQyYZvxN97d9KhdLMOW8XVVk/6sN2Xflw=="
+			"version": "1.4.402",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.402.tgz",
+			"integrity": "sha512-gWYvJSkohOiBE6ecVYXkrDgNaUjo47QEKK0kQzmWyhkH+yoYiG44bwuicTGNSIQRG3WDMsWVZJLRnJnLNkbWvA=="
 		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
@@ -615,30 +619,25 @@
 			}
 		},
 		"node_modules/eslint-plugin-compat": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.0.2.tgz",
-			"integrity": "sha512-xqvoO54CLTVaEYGMzhu35Wzwk/As7rCvz/2dqwnFiWi0OJccEtGIn+5qq3zqIu9nboXlpdBN579fZcItC73Ycg==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.1.4.tgz",
+			"integrity": "sha512-RxySWBmzfIROLFKgeJBJue2BU/6vM2KJWXWAUq+oW4QtrsZXRxbjgxmO1OfF3sHcRuuIenTS/wgo3GyUWZF24w==",
 			"dependencies": {
-				"@mdn/browser-compat-data": "^4.1.5",
-				"ast-metadata-inferer": "^0.7.0",
-				"browserslist": "^4.16.8",
-				"caniuse-lite": "^1.0.30001304",
-				"core-js": "^3.16.2",
+				"@mdn/browser-compat-data": "^5.2.47",
+				"@tsconfig/node14": "^1.0.3",
+				"ast-metadata-inferer": "^0.8.0",
+				"browserslist": "^4.21.5",
+				"caniuse-lite": "^1.0.30001473",
 				"find-up": "^5.0.0",
 				"lodash.memoize": "4.1.2",
-				"semver": "7.3.5"
+				"semver": "7.3.8"
 			},
 			"engines": {
-				"node": ">=9.x"
+				"node": ">=14.x"
 			},
 			"peerDependencies": {
 				"eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
-		},
-		"node_modules/eslint-plugin-compat/node_modules/@mdn/browser-compat-data": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.6.tgz",
-			"integrity": "sha512-JbtcHGODAlkOT6eDV2rCyOguW3+o34ExMD9DOki6kxzeyN3IBtZ9PI0FlbKeD77Bm5U0UG5Heo4qnNbSajXUnw=="
 		},
 		"node_modules/eslint-plugin-es-x": {
 			"version": "5.2.1",
@@ -676,20 +675,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-plugin-json-es": {
@@ -1524,9 +1509,9 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
+			"integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q=="
 		},
 		"node_modules/node-watch": {
 			"version": "0.7.3",
@@ -1961,9 +1946,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -2109,6 +2094,35 @@
 			"engines": {
 				"node": ">=4",
 				"yarn": "*"
+			}
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
 			}
 		},
 		"node_modules/uri-js": {
@@ -2379,9 +2393,9 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
 		},
 		"@mdn/browser-compat-data": {
-			"version": "3.3.14",
-			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
-			"integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA=="
+			"version": "5.2.59",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.59.tgz",
+			"integrity": "sha512-f7VxPGqVLCSe+0KdDas33JyGY+eHJTfBkgAsoiM1BSv7e238FYJMTFwfGLhjnhOwc33wUwsnjiHSfXukwzbqog=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -2405,6 +2419,11 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -2452,11 +2471,11 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"ast-metadata-inferer": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
-			"integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.0.tgz",
+			"integrity": "sha512-jOMKcHht9LxYIEQu+RVd22vtgrPaVCtDRQ/16IGmurdzxvYbDd5ynxjnyrzLnieG96eTcAyaoj/wN/4/1FyyeA==",
 			"requires": {
-				"@mdn/browser-compat-data": "^3.3.14"
+				"@mdn/browser-compat-data": "^5.2.34"
 			}
 		},
 		"balanced-match": {
@@ -2479,15 +2498,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.5.tgz",
-			"integrity": "sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==",
+			"version": "4.21.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001271",
-				"electron-to-chromium": "^1.3.878",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001449",
+				"electron-to-chromium": "^1.4.284",
+				"node-releases": "^2.0.8",
+				"update-browserslist-db": "^1.0.10"
 			}
 		},
 		"browserslist-config-wikimedia": {
@@ -2506,9 +2524,9 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001442",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-			"integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow=="
+			"version": "1.0.30001488",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+			"integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ=="
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -2568,11 +2586,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
-		"core-js": {
-			"version": "3.20.2",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-			"integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2610,9 +2623,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.881",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.881.tgz",
-			"integrity": "sha512-XoAaO4CXk7FXtF2JH0PJ7KgHL1PyZ76G+NhuL337pMiOGlEWwTTSzMQyYZvxN97d9KhdLMOW8XVVk/6sN2Xflw=="
+			"version": "1.4.402",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.402.tgz",
+			"integrity": "sha512-gWYvJSkohOiBE6ecVYXkrDgNaUjo47QEKK0kQzmWyhkH+yoYiG44bwuicTGNSIQRG3WDMsWVZJLRnJnLNkbWvA=="
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -2715,25 +2728,18 @@
 			}
 		},
 		"eslint-plugin-compat": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.0.2.tgz",
-			"integrity": "sha512-xqvoO54CLTVaEYGMzhu35Wzwk/As7rCvz/2dqwnFiWi0OJccEtGIn+5qq3zqIu9nboXlpdBN579fZcItC73Ycg==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.1.4.tgz",
+			"integrity": "sha512-RxySWBmzfIROLFKgeJBJue2BU/6vM2KJWXWAUq+oW4QtrsZXRxbjgxmO1OfF3sHcRuuIenTS/wgo3GyUWZF24w==",
 			"requires": {
-				"@mdn/browser-compat-data": "^4.1.5",
-				"ast-metadata-inferer": "^0.7.0",
-				"browserslist": "^4.16.8",
-				"caniuse-lite": "^1.0.30001304",
-				"core-js": "^3.16.2",
+				"@mdn/browser-compat-data": "^5.2.47",
+				"@tsconfig/node14": "^1.0.3",
+				"ast-metadata-inferer": "^0.8.0",
+				"browserslist": "^4.21.5",
+				"caniuse-lite": "^1.0.30001473",
 				"find-up": "^5.0.0",
 				"lodash.memoize": "4.1.2",
-				"semver": "7.3.5"
-			},
-			"dependencies": {
-				"@mdn/browser-compat-data": {
-					"version": "4.1.6",
-					"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.6.tgz",
-					"integrity": "sha512-JbtcHGODAlkOT6eDV2rCyOguW3+o34ExMD9DOki6kxzeyN3IBtZ9PI0FlbKeD77Bm5U0UG5Heo4qnNbSajXUnw=="
-				}
+				"semver": "7.3.8"
 			}
 		},
 		"eslint-plugin-es-x": {
@@ -2757,16 +2763,6 @@
 				"esquery": "^1.4.0",
 				"semver": "^7.3.7",
 				"spdx-expression-parse": "^3.0.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"eslint-plugin-json-es": {
@@ -3340,9 +3336,9 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"node-releases": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
+			"integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q=="
 		},
 		"node-watch": {
 			"version": "0.7.3",
@@ -3634,9 +3630,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -3743,6 +3739,15 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
 			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w=="
+		},
+		"update-browserslist-db": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			}
 		},
 		"uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	"dependencies": {
 		"browserslist-config-wikimedia": "^0.5.0",
 		"eslint": "^8.31.0",
-		"eslint-plugin-compat": "^4.0.2",
+		"eslint-plugin-compat": "^4.1.4",
 		"eslint-plugin-es-x": "^5.2.1",
 		"eslint-plugin-jsdoc": "39.2.2",
 		"eslint-plugin-json-es": "^1.5.7",


### PR DESCRIPTION
I couldn't find an up-to-date changelog, but https://github.com/amilajack/eslint-plugin-compat/compare/v4.0.2...v4.1.4 seems pretty boring. Most notably, the new version no longer depends on core-js, which is no longer maintained.