### PR TITLE
Require empty line between ES6 class members

### DIFF
--- a/language/rules-es6.json
+++ b/language/rules-es6.json
@@ -5,6 +5,7 @@
 		"arrow-parens": "error",
 		"arrow-spacing": "error",
 		"default-param-last": "error",
+		"lines-between-class-members": "error",
 		"no-constructor-return": "error",
 		"no-misleading-character-class": "error",
 		"no-new-require": "error",

--- a/test/fixtures/server/invalid.js
+++ b/test/fixtures/server/invalid.js
@@ -99,4 +99,6 @@ class A {
 		// eslint-disable-next-line no-constructor-return
 		return a;
 	}
+	// eslint-disable-next-line lines-between-class-members
+	foo() {}
 }


### PR DESCRIPTION
I think this has been a long-standing convention for our ES5 code, and now we can enforce it for ES6 code.