### PR TITLE
common: Remove allowSingleLine exception from brace-style

### DIFF
--- a/common.json
+++ b/common.json
@@ -27,7 +27,7 @@
 		"array-callback-return": "error",
 		"block-scoped-var": "error",
 		"block-spacing": "error",
-		"brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+		"brace-style": [ "error", "1tbs" ],
 		"camelcase": [ "error", { "properties": "always" } ],
 		"comma-dangle": [ "error", "never" ],
 		"comma-spacing": [ "error", { "before": false, "after": true } ],

--- a/test/fixtures/common/invalid.js
+++ b/test/fixtures/common/invalid.js
@@ -54,8 +54,18 @@ var APP;
 			return camel_case + quux + whee;}
 
 		var i;
-		// eslint-disable-next-line max-statements-per-line
+		// eslint-disable-next-line brace-style, max-statements-per-line
 		if ( name ) { return i; }
+
+		if ( name ) {
+			// eslint-disable-next-line max-statements-per-line
+			bar(); return i;
+		}
+
+		if ( name ) {
+			bar();
+		// eslint-disable-next-line brace-style
+		} else { whee(); }
 
 		// eslint-disable-next-line curly, dot-location
 		if ( bar ) return i.
@@ -242,7 +252,9 @@ var APP;
 	Date = APP.Date;
 
 	// eslint-disable-next-line quote-props, object-curly-spacing
-	APP.example = {'default': 'Legacy'
+	APP.example = {'default': 'Legacy',
+		// eslint-disable-next-line brace-style
+		foo: function () { return 1; }
 	};
 
 	// eslint-disable-next-line no-multi-spaces

--- a/test/fixtures/common/valid.js
+++ b/test/fixtures/common/valid.js
@@ -140,7 +140,11 @@
 		var i, len, item, key,
 			// Valid: prefer-numeric-literals
 			j = 1,
-			ret = {};
+			ret = {
+				foo: function () {
+					return 1;
+				}
+			};
 
 		// Valid: for-direction
 		for ( i = 0, len = items.length; i < len; i++ ) {

--- a/vue-common.json
+++ b/vue-common.json
@@ -71,6 +71,7 @@
 					"renderError"
 				]
 			} ],
+			"vue/brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
 			"vue/padding-line-between-blocks": [ "error", "always" ],
 			"vue/v-on-function-call": "error",
 			"vue/component-name-in-template-casing": [ "error", "PascalCase" ],

--- a/vue-wrappers.js
+++ b/vue-wrappers.js
@@ -12,7 +12,6 @@ const rulesToMap = [
 	'array-bracket-spacing',
 	'arrow-spacing',
 	'block-spacing',
-	'brace-style',
 	'camelcase',
 	'comma-dangle',
 	'comma-spacing',


### PR DESCRIPTION
This allowed single line functions, but only if there
were no other statements on the line (e.g. 'return' or 'var')
due to max-statements-per-line. This meant it wasn't clear
when single line functions were allowed.

Also, single line functions are better implemented as arrow
functions in ES6.

It also allowed single line else blocks, which is arguably
against our style guide.

Add an exception for vue where single line code is widely
used in attribute values.

Fixes #511
