### PR TITLE
jsdoc: Upgrade eslint-plugin-jsdoc from 39.2.2 to 39.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"eslint-plugin-compat": "^4.2.0",
 				"eslint-plugin-es-x": "^7.1.0",
 				"eslint-plugin-jest": "^27.2.3",
-				"eslint-plugin-jsdoc": "39.2.2",
+				"eslint-plugin-jsdoc": "39.9.1",
 				"eslint-plugin-json-es": "^1.5.7",
 				"eslint-plugin-mediawiki": "^0.5.0",
 				"eslint-plugin-mocha": "^10.1.0",
@@ -130,16 +130,16 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.23.6",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.23.6.tgz",
-			"integrity": "sha512-cCtumxG+qrYORGeOkDQ58GtSt/bb2XiP9GC0x2YduoUEX2EmBQ48FtoZMUs+8wiIdTDN1izUiRUD2FDu+p+Lvg==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"dependencies": {
 				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.5"
+				"jsdoc-type-pratt-parser": "~3.1.0"
 			},
 			"engines": {
-				"node": "^12 || ^14 || ^16 || ^17"
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -905,20 +905,20 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "39.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.2.tgz",
-			"integrity": "sha512-ybkvja0p9JRzHEd2ST9h+Z47DLOuPyXpeb6r18/zKHdMmggPU1J0/zl+F0phea8ze9rMxi42MJVmGXi2NZ7PpA==",
+			"version": "39.9.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.9.1.tgz",
+			"integrity": "sha512-Rq2QY6BZP2meNIs48aZ3GlIlJgBqFCmR55+UBvaDkA3ZNQ0SvQXOs2QKkubakEijV8UbIVbVZKsOVN8G3MuqZw==",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.23.1",
+				"@es-joy/jsdoccomment": "~0.36.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"semver": "^7.3.7",
+				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"engines": {
-				"node": "^14 || ^16 || ^17"
+				"node": "^14 || ^16 || ^17 || ^18 || ^19"
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
@@ -1672,9 +1672,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -2740,13 +2740,13 @@
 			}
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.23.6",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.23.6.tgz",
-			"integrity": "sha512-cCtumxG+qrYORGeOkDQ58GtSt/bb2XiP9GC0x2YduoUEX2EmBQ48FtoZMUs+8wiIdTDN1izUiRUD2FDu+p+Lvg==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"requires": {
 				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.5"
+				"jsdoc-type-pratt-parser": "~3.1.0"
 			}
 		},
 		"@eslint-community/eslint-utils": {
@@ -3257,16 +3257,16 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "39.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.2.tgz",
-			"integrity": "sha512-ybkvja0p9JRzHEd2ST9h+Z47DLOuPyXpeb6r18/zKHdMmggPU1J0/zl+F0phea8ze9rMxi42MJVmGXi2NZ7PpA==",
+			"version": "39.9.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.9.1.tgz",
+			"integrity": "sha512-Rq2QY6BZP2meNIs48aZ3GlIlJgBqFCmR55+UBvaDkA3ZNQ0SvQXOs2QKkubakEijV8UbIVbVZKsOVN8G3MuqZw==",
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.23.1",
+				"@es-joy/jsdoccomment": "~0.36.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"semver": "^7.3.7",
+				"semver": "^7.3.8",
 				"spdx-expression-parse": "^3.0.1"
 			}
 		},
@@ -3794,9 +3794,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+			"integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw=="
 		},
 		"jsesc": {
 			"version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"eslint-plugin-compat": "^4.2.0",
 		"eslint-plugin-es-x": "^7.1.0",
 		"eslint-plugin-jest": "^27.2.3",
-		"eslint-plugin-jsdoc": "39.2.2",
+		"eslint-plugin-jsdoc": "39.9.1",
 		"eslint-plugin-json-es": "^1.5.7",
 		"eslint-plugin-mediawiki": "^0.5.0",
 		"eslint-plugin-mocha": "^10.1.0",

--- a/test/fixtures/jsdoc/invalid.js
+++ b/test/fixtures/jsdoc/invalid.js
@@ -67,13 +67,15 @@
 	};
 	/* eslint-enable jsdoc/require-returns, jsdoc/require-returns-check */
 
-	// eslint-disable-next-line jsdoc/implements-on-classes, jsdoc/require-asterisk-prefix
+	/* eslint-disable jsdoc/require-asterisk-prefix */
+	// eslint-disable-next-line jsdoc/implements-on-classes
 	/**
 	 @implements {HTMLElement}
 	 */
 	APP.method = function ( bar ) {
 		return bar;
 	};
+	/* eslint-enable jsdoc/require-asterisk-prefix */
 
 	// eslint-disable-next-line jsdoc/require-returns-type
 	/**

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -12,6 +12,7 @@
 // Off: jsdoc/require-file-overview
 // Off: jsdoc/require-hyphen-before-param-description
 // Off: jsdoc/require-property
+// Off: jsdoc/text-escaping
 ( function () {
 	// Off: jsdoc/require-property-description
 	// Off: jsdoc/require-property-name


### PR DESCRIPTION
Changes: https://github.com/gajus/eslint-plugin-jsdoc/compare/v39.2.2...v39.9.1

Fixes #510