### PR TITLE
Assert that valid fixtures contain no disables

### DIFF
--- a/test/fixtures/client-common/invalid.js
+++ b/test/fixtures/client-common/invalid.js
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 ( function () {
 	// eslint-disable-next-line no-alert
 	window.alert( name );

--- a/test/fixtures/client-common/valid.js
+++ b/test/fixtures/client-common/valid.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 ( function () {
 	function checkHash( input, cachedValue ) {
 		var hash = JSON.stringify( input );

--- a/test/fixtures/client-common/valid.js
+++ b/test/fixtures/client-common/valid.js
@@ -1,10 +1,12 @@
 /* eslint-env browser */
-
-// eslint-disable-next-line no-implicit-globals, no-unused-vars
-function checkHash( input, cachedValue ) {
-	var hash = JSON.stringify( input );
-	// Off: security/detect-possible-timing-attacks (#503)
-	if ( hash === cachedValue ) {
-		return true;
+( function () {
+	function checkHash( input, cachedValue ) {
+		var hash = JSON.stringify( input );
+		// Off: security/detect-possible-timing-attacks (#503)
+		if ( hash === cachedValue ) {
+			return true;
+		}
 	}
-}
+
+	checkHash();
+}() );

--- a/test/fixtures/client-es5/invalid.js
+++ b/test/fixtures/client-es5/invalid.js
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 ( function () {
 	var node;
 

--- a/test/fixtures/client-es5/valid.js
+++ b/test/fixtures/client-es5/valid.js
@@ -15,7 +15,6 @@
 	Object.keys();
 
 	// Off: es-x/no-array-prototype-values
-	// eslint-disable-next-line no-unused-expressions
-	$div.values;
+	window.val = $div.values;
 
 }() );

--- a/test/fixtures/client-es5/valid.js
+++ b/test/fixtures/client-es5/valid.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 ( function () {
 	var $div;
 	// [].find should be disabled, but it conflicts with jQuery

--- a/test/fixtures/client-es6/invalid.js
+++ b/test/fixtures/client-es6/invalid.js
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 // eslint-disable-next-line no-use-before-define
 const c = new MyClass();
 

--- a/test/fixtures/client-es6/valid.js
+++ b/test/fixtures/client-es6/valid.js
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 ( function () {
 	let node;
 

--- a/test/fixtures/client-es6/valid.js
+++ b/test/fixtures/client-es6/valid.js
@@ -82,6 +82,5 @@
 	// Symbol.prototype.descrition is disabled, but conflicts
 	// with many plain object properties.
 	// Off: es-x/no-symbol-prototype-description
-	// eslint-disable-next-line no-unused-expressions
-	node.description;
+	window.desc = node.description;
 }() );

--- a/test/fixtures/mediawiki/valid.vue
+++ b/test/fixtures/mediawiki/valid.vue
@@ -21,7 +21,7 @@
 			This line asserts valid code for the no-child-content rule, but there's no way
 			to do that without running afoul of the no-v-html rule
 		-->
-		<!-- eslint-disable-next-line vue/no-v-html -->
+		<!-- eslint-disable-next-line vue/no-v-html !allowdisable -->
 		<p v-html="foo"></p>
 		<p v-i18n-html:foo></p>
 	</div>
@@ -37,8 +37,9 @@ module.exports = {
 };
 
 // Off: no-implicit-globals
-// eslint-disable-next-line no-unused-vars
 function x() {}
+// Avoid triggering no-unused-vars
+x();
 </script>
 
 <style>

--- a/test/fixtures/server/valid.js
+++ b/test/fixtures/server/valid.js
@@ -25,8 +25,7 @@
 	}
 
 	// Valid: template-curly-spacing
-	// eslint-disable-next-line no-unused-expressions
-	`${ global.foo }`;
+	global.template = `${ global.foo }`;
 
 	// ES6
 	// Valid: no-restricted-syntax
@@ -52,7 +51,6 @@
 	// Symbol.prototype.descrition is disabled, but conflicts
 	// with many plain object properties.
 	// Off: es-x/no-symbol-prototype-description
-	// eslint-disable-next-line no-unused-expressions
-	a.description;
+	global.desc = a.description;
 
 }( this ) );

--- a/test/fixtures/vue2-common/valid.vue
+++ b/test/fixtures/vue2-common/valid.vue
@@ -21,7 +21,7 @@
 			This line asserts valid code for the no-child-content rule, but there's no way
 			to do that without running afoul of the no-v-html rule
 		-->
-		<!-- eslint-disable-next-line vue/no-v-html -->
+		<!-- eslint-disable-next-line vue/no-v-html !allowdisable -->
 		<p v-html="foo" />
 		<!-- Valid: vue/prefer-separate-static-class -->
 		<div class="myDiv" :class="foo" />

--- a/test/test.js
+++ b/test/test.js
@@ -192,6 +192,10 @@ configs.forEach( ( configPath ) => {
 			fs.readFileSync( file ).toString()
 		).join( '' );
 
+		QUnit.test( 'Valid fixtures contain no disables', ( assert ) => {
+			assert.true( !/eslint-disable(?!.*!allowdisable)/.test( validFixtures ), 'No disables found in valid fixtures' );
+		} );
+
 		Object.keys( rules ).forEach( ( rule ) => {
 			// eslint-disable-next-line security/detect-non-literal-regexp
 			const rEnableRule = new RegExp( `Off: ${ rule }($|[^a-z-])` );


### PR DESCRIPTION
Valid fixtures should contain only valid code. Adding an inline
disable should not be allowed.

In rare edge cases we need to trigger an error to assert that
another rule is valid, in which case allow an override.
