### PR TITLE
Allow the variable "hooks" to be shadowed in QUnit

### DIFF
--- a/qunit.json
+++ b/qunit.json
@@ -7,6 +7,7 @@
 	},
 	"plugins": [ "qunit" ],
 	"rules": {
+		"no-shadow": [ "error", { "allow": [ "hooks" ] } ],
 		"qunit/no-assert-equal": "off",
 		"qunit/no-assert-equal-boolean": "off",
 		"qunit/no-assert-logical-expression": "off",

--- a/test/fixtures/qunit/invalid.js
+++ b/test/fixtures/qunit/invalid.js
@@ -91,7 +91,13 @@ QUnit.asyncTest( 'Asynchronous test', 3, function () {
 // eslint-disable-next-line qunit/no-async-module-callbacks
 QUnit.module( 'An async module', async function () {
 	QUnit.test( 'a passing test', function ( assert ) {
-		assert.true( true );
+		// Shadowing is only allowed for the variable name "hooks" (#532)
+		// eslint-disable-next-line no-shadow
+		function checkAssert( assert ) {
+			return !!assert;
+		}
+
+		assert.true( checkAssert( assert ) );
 	} );
 
 	await Promise.resolve();

--- a/test/fixtures/qunit/valid.js
+++ b/test/fixtures/qunit/valid.js
@@ -1,32 +1,46 @@
-QUnit.module( 'Example' );
+QUnit.module( 'Module', ( hooks ) => {
 
-// Off: qunit/no-arrow-tests
-// Valid: qunit/require-expect
-QUnit.test( '.foo()', () => {
-} );
+	hooks.beforeEach( ( assert ) => {
+		assert.ok( true, 'beforeEach' );
+	} );
 
-QUnit.test( '.bar()', function ( assert ) {
-	const x = 'bar',
-		y = 'baz';
+	// Off: qunit/no-arrow-tests
+	// Valid: qunit/require-expect
+	QUnit.test( '.foo()', () => {
+	} );
 
-	// The following rules are superseded by qunit/no-loose-assertions,
-	// so are turned off to avoid double errors.
-	// Off: qunit/no-assert-equal
-	// Off: qunit/no-negated-ok
-	// Off: qunit/no-ok-equality
+	QUnit.test( '.bar()', function ( assert ) {
+		const x = 'bar',
+			y = 'baz';
 
-	// Valid: qunit/no-assert-equal
-	assert.strictEqual( x, 'bar' );
+		// The following rules are superseded by qunit/no-loose-assertions,
+		// so are turned off to avoid double errors.
+		// Off: qunit/no-assert-equal
+		// Off: qunit/no-negated-ok
+		// Off: qunit/no-ok-equality
 
-	// Off: qunit/no-assert-equal-boolean
-	assert.strictEqual( x, true );
+		// Valid: qunit/no-assert-equal
+		assert.strictEqual( x, 'bar' );
 
-	// Valid: qunit/no-negated-ok
-	if ( x ) {
-		// Off: qunit/no-conditional-assertions
-		assert.true( x );
-	}
+		// Off: qunit/no-assert-equal-boolean
+		assert.strictEqual( x, true );
 
-	// Off: qunit/no-assert-logical-expression
-	assert.true( x && y );
+		// Valid: qunit/no-negated-ok
+		if ( x ) {
+			// Off: qunit/no-conditional-assertions
+			assert.true( x );
+		}
+
+		// Off: qunit/no-assert-logical-expression
+		assert.true( x && y );
+	} );
+
+	// Valid: no-shadow
+	// The variable name "hooks" can be shadowed (#532)
+	QUnit.module( 'Nested module', ( hooks ) => {
+		hooks.beforeEach( ( assert ) => {
+			assert.ok( true, 'nested beforeEach' );
+		} );
+	} );
+
 } );


### PR DESCRIPTION
Fixes #532