### PR TITLE
jsdoc: add @ignore, @internal and @stable as definedTags

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -39,6 +39,16 @@
 	},
 	"rules": {
 		"jsdoc/check-param-names": [ "warn", { "allowExtraTrailingParamDocs": true } ],
+		"jsdoc/check-tag-names": [
+			"warn",
+			{
+				"definedTags": [
+					"ignore",
+					"internal",
+					"stable"
+				]
+			}
+		],
 		"jsdoc/check-values": "off",
 		"jsdoc/empty-tags": "off",
 		"jsdoc/no-multi-asterisks": [ "error", { "allowWhitespace": true } ],

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -155,6 +155,9 @@
 	 *                 line
 	 * @yield {number} Multi-
 	 *                 line
+	 * @ignore
+	 * @internal
+	 * @stable
 	 */
 	APP.JSDocTags = function ( a, b ) {
 		return a || b;


### PR DESCRIPTION
This will be used to indicate the stability of JS methods, following the introduction of the frontend stable interface policy: https://w.wiki/87wa

See https://www.mediawiki.org/wiki/Topic:Xrs17s867zgd9j7b