### PR TITLE
jquery: Raise tested version to 3.7, to match MediaWiki

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -5,7 +5,7 @@
 	"plugins": [ "no-jquery" ],
 	"extends": [
 		"plugin:no-jquery/recommended",
-		"plugin:no-jquery/deprecated-3.5"
+		"plugin:no-jquery/deprecated-3.7"
 	],
 	"rules": {
 		"no-jquery/no-animate": [ "error", { "allowScroll": true } ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"eslint-plugin-mediawiki": "^0.7.0",
 				"eslint-plugin-mocha": "^10.4.3",
 				"eslint-plugin-n": "^17.7.0",
-				"eslint-plugin-no-jquery": "^2.7.0",
+				"eslint-plugin-no-jquery": "^3.0.0",
 				"eslint-plugin-qunit": "^8.1.1",
 				"eslint-plugin-security": "^1.7.1",
 				"eslint-plugin-unicorn": "^53.0.0",
@@ -1106,11 +1106,11 @@
 			}
 		},
 		"node_modules/eslint-plugin-no-jquery": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.7.0.tgz",
-			"integrity": "sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-3.0.0.tgz",
+			"integrity": "sha512-I98ZWtdn9sYio4L5pRjyLVd+8BPuQcUQjucRzvqVLbsGhZbFd5BPTbIP/s6vj5ZFm95oPi67+niO00q6WMeJvw==",
 			"peerDependencies": {
-				"eslint": ">=2.3.0"
+				"eslint": ">=8.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-qunit": {
@@ -3479,9 +3479,9 @@
 			}
 		},
 		"eslint-plugin-no-jquery": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.7.0.tgz",
-			"integrity": "sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-3.0.0.tgz",
+			"integrity": "sha512-I98ZWtdn9sYio4L5pRjyLVd+8BPuQcUQjucRzvqVLbsGhZbFd5BPTbIP/s6vj5ZFm95oPi67+niO00q6WMeJvw==",
 			"requires": {}
 		},
 		"eslint-plugin-qunit": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"eslint-plugin-mediawiki": "^0.7.0",
 		"eslint-plugin-mocha": "^10.4.3",
 		"eslint-plugin-n": "^17.7.0",
-		"eslint-plugin-no-jquery": "^2.7.0",
+		"eslint-plugin-no-jquery": "^3.0.0",
 		"eslint-plugin-qunit": "^8.1.1",
 		"eslint-plugin-security": "^1.7.1",
 		"eslint-plugin-unicorn": "^53.0.0",


### PR DESCRIPTION
* jquery: Raise tested version to 3.7, to match MediaWiki
* jquery: Upgrade eslint-plugin-no-jquery to 3.0.0