### PR TITLE
vue: bump vue/no-unsupported-features to 3.4.27

### DIFF
--- a/vue3/common.json
+++ b/vue3/common.json
@@ -7,7 +7,7 @@
 		],
 		"rules": {
 			"vue/no-unsupported-features": [ "error", {
-				"version": "^3.2.0"
+				"version": "^3.4.27"
 			} ]
 		}
 	} ]


### PR DESCRIPTION
Vue version packaged in MW core is v3.4.27, as of [4806575](https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/4806575).

This allows usage of the following features (from https://eslint.vuejs.org/rules/no-unsupported-features.html#options):

-   Vue.js 3.4.0+

    -   "define-model" ... defineModel() macro.
    -   "v-bind-same-name-shorthand" ... v-bind same-name shorthand.

-   Vue.js 3.3.0+
    -   "define-slots" ... defineSlots() macro.
    -   "define-options" ... defineOptions() macro.
