### PR TITLE
jquery: Enable no-done-fail

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -12,6 +12,7 @@
 		"no-jquery/no-animate-toggle": "error",
 		"no-jquery/no-class-state": "error",
 		"no-jquery/no-constructor-attributes": "error",
+		"no-jquery/no-done-fail": "error",
 		"no-jquery/no-each-util": "error",
 		"no-jquery/no-error": "error",
 		"no-jquery/no-extend": [ "error", { "allowDeep": true } ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"eslint-plugin-mediawiki": "^0.7.0",
 				"eslint-plugin-mocha": "^10.4.3",
 				"eslint-plugin-n": "^17.7.0",
-				"eslint-plugin-no-jquery": "^3.0.2",
+				"eslint-plugin-no-jquery": "^3.1.0",
 				"eslint-plugin-qunit": "^8.1.1",
 				"eslint-plugin-security": "^1.7.1",
 				"eslint-plugin-unicorn": "^53.0.0",
@@ -608,9 +608,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001600",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
-			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+			"version": "1.0.30001685",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001685.tgz",
+			"integrity": "sha512-e/kJN1EMyHQzgcMEEgoo+YTCO1NGCmIYHk5Qk8jT6AazWemS5QFKJ5ShCJlH3GZrNIdZofcNCEwZqbMjjKzmnA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1106,9 +1106,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-no-jquery": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-3.0.2.tgz",
-			"integrity": "sha512-n/+6p6PFhWDNPVLJj1463hw4OTIRBbROGcbhmtOHTgw7yihSKzkwZiQ00EJTneyeR3jRiw5lpWSMCCBhtb8t2g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-3.1.0.tgz",
+			"integrity": "sha512-Ze+eRlAbLAoceBqMXI2E9s6o3dC7zE75niP2Sy4D8I/u1TyLegrIpjc4emPN90dH0IA+uXNUmQbzBuCaihxwIQ==",
 			"peerDependencies": {
 				"eslint": ">=8.0.0"
 			}
@@ -3140,9 +3140,9 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001600",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
-			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ=="
+			"version": "1.0.30001685",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001685.tgz",
+			"integrity": "sha512-e/kJN1EMyHQzgcMEEgoo+YTCO1NGCmIYHk5Qk8jT6AazWemS5QFKJ5ShCJlH3GZrNIdZofcNCEwZqbMjjKzmnA=="
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -3479,9 +3479,9 @@
 			}
 		},
 		"eslint-plugin-no-jquery": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-3.0.2.tgz",
-			"integrity": "sha512-n/+6p6PFhWDNPVLJj1463hw4OTIRBbROGcbhmtOHTgw7yihSKzkwZiQ00EJTneyeR3jRiw5lpWSMCCBhtb8t2g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-3.1.0.tgz",
+			"integrity": "sha512-Ze+eRlAbLAoceBqMXI2E9s6o3dC7zE75niP2Sy4D8I/u1TyLegrIpjc4emPN90dH0IA+uXNUmQbzBuCaihxwIQ==",
 			"requires": {}
 		},
 		"eslint-plugin-qunit": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"eslint-plugin-mediawiki": "^0.7.0",
 		"eslint-plugin-mocha": "^10.4.3",
 		"eslint-plugin-n": "^17.7.0",
-		"eslint-plugin-no-jquery": "^3.0.2",
+		"eslint-plugin-no-jquery": "^3.1.0",
 		"eslint-plugin-qunit": "^8.1.1",
 		"eslint-plugin-security": "^1.7.1",
 		"eslint-plugin-unicorn": "^53.0.0",

--- a/test/fixtures/jquery/invalid.js
+++ b/test/fixtures/jquery/invalid.js
@@ -65,6 +65,9 @@
 	// eslint-disable-next-line no-jquery/no-trim
 	$.trim( ' foo ' );
 
+	// eslint-disable-next-line no-jquery/no-done-fail
+	$.promise().done( function () {} );
+
 	// Recommended
 	// eslint-disable-next-line no-jquery/variable-pattern
 	div = $div.find( '.foo' );


### PR DESCRIPTION
Raise eslint-plugin-no-jquery to 3.1.0+ to provide new rules.