### PR TITLE
vue: Rule change: `vue/no-unsupported-features`: Target version 3.5.13, up from 2.6.11

### DIFF
--- a/client/es6.json
+++ b/client/es6.json
@@ -2,6 +2,6 @@
 	"extends": [
 		"./common",
 		"../language/es6",
-		"../vue/es6"
+		"../vue3/es6"
 	]
 }

--- a/vue/common.json
+++ b/vue/common.json
@@ -30,7 +30,7 @@
 			"vue/no-undef-properties": "error",
 			"vue/no-undef-components": "error",
 			"vue/no-unsupported-features": [ "error", {
-				"version": "2.6.11"
+				"version": "3.5.13"
 			} ],
 			"vue/no-unused-properties": [ "error", {
 				"groups": [ "props", "data", "computed", "methods", "setup" ],

--- a/vue3/common.json
+++ b/vue3/common.json
@@ -7,7 +7,7 @@
 		],
 		"rules": {
 			"vue/no-unsupported-features": [ "error", {
-				"version": "^3.4.27"
+				"version": "3.5.13"
 			} ]
 		}
 	} ]


### PR DESCRIPTION
We've been on Vue 3.x for a while, and 3.5.x since last month.