### PR TITLE
mediawiki: set "sourceType" to "commonjs" and enable "no-implicit-globals"

### DIFF
--- a/mediawiki/common.js
+++ b/mediawiki/common.js
@@ -23,12 +23,14 @@ const config = {
 			browsers.join( ',' )
 		]
 	},
+	"parserOptions": {
+		"sourceType": "commonjs"
+	},
 	"overrides": [
 		{
 			"files": [ "**/*.vue" ],
 			"extends": [ "plugin:mediawiki/vue" ],
 			"rules": {
-				"no-implicit-globals": "off",
 				"vue/html-self-closing": [ "error", {
 					"html": {
 						"void": "never",


### PR DESCRIPTION
Bug: [T367441](https://phabricator.wikimedia.org/T367441)