### PR TITLE
build: Specify our Node supported range per CI in package.engines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,9 @@
 				"escape-string-regexp": "^4.0.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"qunit": "^2.24.1"
+			},
+			"engines": {
+				"node": ">=18 <23"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
 		"eslintconfig",
 		"wikimedia"
 	],
-	"engine": {
-		"node": ">=18"
+	"engines": {
+		"node": ">=18 <23"
 	},
 	"files": [
 		"common.json",


### PR DESCRIPTION
This fixes a typo ('engines', not 'engine'), and sets an upper bound on the versions of Node we're likely to support which is the range we have set as our testing targets in .github/workflows/nodejs.yaml, 18–22.