### PR TITLE
Add config for TypeScript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Next release
+===================
+* Add config for TypeScript, copied from WMDE's typescript eslint config (Michael Große)
+
 0.30.0 / 2025-05-22
 ===================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-Next release
-===================
-* Add config for TypeScript, copied from WMDE's typescript eslint config (Michael Große)
-
 0.30.0 / 2025-05-22
 ===================
 

--- a/common.json
+++ b/common.json
@@ -19,18 +19,8 @@
 			"extends": "./yaml"
 		},
 		{
-			"files": [
-				"**/*.ts"
-			],
-			"extends": [
-				"./typescript.js"
-			],
-			"rules": {
-				"comma-dangle": [
-					"error",
-					"always-multiline"
-				]
-			}
+			"files": [ "**/*.ts" ],
+			"extends": "./typescript"
 		}
 	],
 	"plugins": [ "security", "unicorn" ],

--- a/common.json
+++ b/common.json
@@ -17,6 +17,20 @@
 		{
 			"files": [ "**/*.yaml", "**/*.yml" ],
 			"extends": "./yaml"
+		},
+		{
+			"files": [
+				"**/*.ts"
+			],
+			"extends": [
+				"./typescript.js"
+			],
+			"rules": {
+				"comma-dangle": [
+					"error",
+					"always-multiline"
+				]
+			}
 		}
 	],
 	"plugins": [ "security", "unicorn" ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.30.0",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "^8.0.0",
-				"@typescript-eslint/parser": "^8.0.0",
+				"@typescript-eslint/eslint-plugin": "8.35.1",
+				"@typescript-eslint/parser": "8.35.1",
 				"browserslist-config-wikimedia": "^0.7.0",
 				"eslint": "^8.57.0",
 				"eslint-plugin-compat": "^4.2.0",
@@ -255,16 +255,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.0.tgz",
-			"integrity": "sha512-ijItUYaiWuce0N1SoSMrEd0b6b6lYkYt99pqCPfybd+HKVXtEvYhICfLdwp42MhiI5mp0oq7PKEL+g1cNiz/Eg==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
+			"integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.35.0",
-				"@typescript-eslint/type-utils": "8.35.0",
-				"@typescript-eslint/utils": "8.35.0",
-				"@typescript-eslint/visitor-keys": "8.35.0",
+				"@typescript-eslint/scope-manager": "8.35.1",
+				"@typescript-eslint/type-utils": "8.35.1",
+				"@typescript-eslint/utils": "8.35.1",
+				"@typescript-eslint/visitor-keys": "8.35.1",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -278,7 +278,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.35.0",
+				"@typescript-eslint/parser": "^8.35.1",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <5.9.0"
 			}
@@ -293,15 +293,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
-			"integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
+			"integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.35.0",
-				"@typescript-eslint/types": "8.35.0",
-				"@typescript-eslint/typescript-estree": "8.35.0",
-				"@typescript-eslint/visitor-keys": "8.35.0",
+				"@typescript-eslint/scope-manager": "8.35.1",
+				"@typescript-eslint/types": "8.35.1",
+				"@typescript-eslint/typescript-estree": "8.35.1",
+				"@typescript-eslint/visitor-keys": "8.35.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -317,13 +317,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
-			"integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
+			"integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.35.0",
-				"@typescript-eslint/types": "^8.35.0",
+				"@typescript-eslint/tsconfig-utils": "^8.35.1",
+				"@typescript-eslint/types": "^8.35.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -338,13 +338,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
-			"integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+			"integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.35.0",
-				"@typescript-eslint/visitor-keys": "8.35.0"
+				"@typescript-eslint/types": "8.35.1",
+				"@typescript-eslint/visitor-keys": "8.35.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -355,9 +355,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
-			"integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
+			"integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -371,13 +371,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.0.tgz",
-			"integrity": "sha512-ceNNttjfmSEoM9PW87bWLDEIaLAyR+E6BoYJQ5PfaDau37UGca9Nyq3lBk8Bw2ad0AKvYabz6wxc7DMTO2jnNA==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
+			"integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.35.0",
-				"@typescript-eslint/utils": "8.35.0",
+				"@typescript-eslint/typescript-estree": "8.35.1",
+				"@typescript-eslint/utils": "8.35.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -394,9 +394,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
-			"integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+			"integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -407,15 +407,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
-			"integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+			"integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.35.0",
-				"@typescript-eslint/tsconfig-utils": "8.35.0",
-				"@typescript-eslint/types": "8.35.0",
-				"@typescript-eslint/visitor-keys": "8.35.0",
+				"@typescript-eslint/project-service": "8.35.1",
+				"@typescript-eslint/tsconfig-utils": "8.35.1",
+				"@typescript-eslint/types": "8.35.1",
+				"@typescript-eslint/visitor-keys": "8.35.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -459,15 +459,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
-			"integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+			"integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.35.0",
-				"@typescript-eslint/types": "8.35.0",
-				"@typescript-eslint/typescript-estree": "8.35.0"
+				"@typescript-eslint/scope-manager": "8.35.1",
+				"@typescript-eslint/types": "8.35.1",
+				"@typescript-eslint/typescript-estree": "8.35.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -482,12 +482,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.35.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
-			"integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
+			"version": "8.35.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+			"integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.35.0",
+				"@typescript-eslint/types": "8.35.1",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.30.0",
 			"license": "MIT",
 			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "^8.0.0",
+				"@typescript-eslint/parser": "^8.0.0",
 				"browserslist-config-wikimedia": "^0.7.0",
 				"eslint": "^8.57.0",
 				"eslint-plugin-compat": "^4.2.0",
@@ -33,7 +35,7 @@
 				"qunit": "^2.24.1"
 			},
 			"engines": {
-				"node": ">=18 <23"
+				"node": ">=18 <25"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -252,14 +254,97 @@
 			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
 			"license": "MIT"
 		},
-		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
-			"integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.0.tgz",
+			"integrity": "sha512-ijItUYaiWuce0N1SoSMrEd0b6b6lYkYt99pqCPfybd+HKVXtEvYhICfLdwp42MhiI5mp0oq7PKEL+g1cNiz/Eg==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1"
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "8.35.0",
+				"@typescript-eslint/type-utils": "8.35.0",
+				"@typescript-eslint/utils": "8.35.0",
+				"@typescript-eslint/visitor-keys": "8.35.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^7.0.0",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.35.0",
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
+			"integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.35.0",
+				"@typescript-eslint/types": "8.35.0",
+				"@typescript-eslint/typescript-estree": "8.35.0",
+				"@typescript-eslint/visitor-keys": "8.35.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
+			"integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.35.0",
+				"@typescript-eslint/types": "^8.35.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
+			"integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.35.0",
+				"@typescript-eslint/visitor-keys": "8.35.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -269,10 +354,49 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
+			"integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.0.tgz",
+			"integrity": "sha512-ceNNttjfmSEoM9PW87bWLDEIaLAyR+E6BoYJQ5PfaDau37UGca9Nyq3lBk8Bw2ad0AKvYabz6wxc7DMTO2jnNA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "8.35.0",
+				"@typescript-eslint/utils": "8.35.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <5.9.0"
+			}
+		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
-			"integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
+			"integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -283,13 +407,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
-			"integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
+			"integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/visitor-keys": "8.32.1",
+				"@typescript-eslint/project-service": "8.35.0",
+				"@typescript-eslint/tsconfig-utils": "8.35.0",
+				"@typescript-eslint/types": "8.35.0",
+				"@typescript-eslint/visitor-keys": "8.35.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -309,9 +435,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -333,15 +459,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
-			"integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
+			"integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.32.1",
-				"@typescript-eslint/types": "8.32.1",
-				"@typescript-eslint/typescript-estree": "8.32.1"
+				"@typescript-eslint/scope-manager": "8.35.0",
+				"@typescript-eslint/types": "8.35.0",
+				"@typescript-eslint/typescript-estree": "8.35.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -356,13 +482,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.32.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
-			"integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
+			"integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.32.1",
-				"eslint-visitor-keys": "^4.2.0"
+				"@typescript-eslint/types": "8.35.0",
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -373,9 +499,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"eslint-plugin-yml": "^1.14.0"
 			},
 			"devDependencies": {
+				"@stylistic/eslint-plugin": "^3.1.0",
 				"escape-string-regexp": "^4.0.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"qunit": "^2.24.1"
@@ -224,6 +225,70 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
+			"integrity": "sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/utils": "^8.13.0",
+				"eslint-visitor-keys": "^4.2.0",
+				"espree": "^10.3.0",
+				"estraverse": "^5.3.0",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/espree": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@types/eslint": {
@@ -517,9 +582,9 @@
 			"license": "ISC"
 		},
 		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"eslint-plugin-yml": "^1.14.0"
 	},
 	"devDependencies": {
+		"@stylistic/eslint-plugin": "^3.1.0",
 		"escape-string-regexp": "^4.0.0",
 		"fs-readdir-recursive": "^1.1.0",
 		"qunit": "^2.24.1"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"qunit.json",
 		"selenium.json",
 		"server.json",
+		"typescript.js",
 		"yaml.json",
 		"client/",
 		"language/",
@@ -52,6 +53,8 @@
 	],
 	"license": "MIT",
 	"dependencies": {
+		"@typescript-eslint/eslint-plugin": "^8.0.0",
+		"@typescript-eslint/parser": "^8.0.0",
 		"browserslist-config-wikimedia": "^0.7.0",
 		"eslint": "^8.57.0",
 		"eslint-plugin-compat": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
 	],
 	"license": "MIT",
 	"dependencies": {
-		"@typescript-eslint/eslint-plugin": "^8.0.0",
-		"@typescript-eslint/parser": "^8.0.0",
+		"@typescript-eslint/eslint-plugin": "8.35.1",
+		"@typescript-eslint/parser": "8.35.1",
 		"browserslist-config-wikimedia": "^0.7.0",
 		"eslint": "^8.57.0",
 		"eslint-plugin-compat": "^4.2.0",

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,38 @@ The `wikimedia/server` config consists of `wikimedia`, `wikimedia/node` and `wik
 }
 ```
 
+### TypeScript
+TypeScript cannot be directly handled by the browser (or ResourceLoader), so it will always target either code that runs
+on the server or tests or code that is compiled to JavaScript first in a non-MediaWiki step. Adjust the outer "extends"
+accordingly. If you have a "mixed" project or are adopting TypeScript incrementally then you can use the typescript
+config only for TypeScript files like so:
+
+`.eslintrc.json`:
+```json
+{
+	"root": true,
+	"extends": [
+		"wikimedia/server"
+	],
+	"overrides": [
+		{
+			"files": [
+				"**/*.ts"
+			],
+			"extends": [
+				"wikimedia/typescript"
+			],
+			"rules": {
+				"comma-dangle": [
+					"error",
+					"always-multiline"
+				]
+			}
+		}
+	]
+}
+```
+
 ### A basic project
 Please note that the basic project configuration does not specify any language or environmental defaults, and is unlikely to be suitable. However, if you wish to target clients with ES3 language support, or earlier versions of Node, this is a good place from which to start.
 

--- a/readme.md
+++ b/readme.md
@@ -121,35 +121,8 @@ The `wikimedia/server` config consists of `wikimedia`, `wikimedia/node` and `wik
 
 ### TypeScript
 TypeScript cannot be directly handled by the browser (or ResourceLoader), so it will always target either code that runs
-on the server or tests or code that is compiled to JavaScript first in a non-MediaWiki step. Adjust the outer "extends"
-accordingly. If you have a "mixed" project or are adopting TypeScript incrementally then you can use the typescript
-config only for TypeScript files like so:
-
-`.eslintrc.json`:
-```json
-{
-	"root": true,
-	"extends": [
-		"wikimedia/server"
-	],
-	"overrides": [
-		{
-			"files": [
-				"**/*.ts"
-			],
-			"extends": [
-				"wikimedia/typescript"
-			],
-			"rules": {
-				"comma-dangle": [
-					"error",
-					"always-multiline"
-				]
-			}
-		}
-	]
-}
-```
+on the server or tests or code that is compiled to JavaScript first in a non-MediaWiki step.
+TypeScript files are automatically included, similar to JSON and YAML files.
 
 ### A basic project
 Please note that the basic project configuration does not specify any language or environmental defaults, and is unlikely to be suitable. However, if you wish to target clients with ES3 language support, or earlier versions of Node, this is a good place from which to start.

--- a/test/fixtures/typescript/invalid.ts
+++ b/test/fixtures/typescript/invalid.ts
@@ -1,0 +1,70 @@
+// eslint-disable-next-line @typescript-eslint/array-type
+const x: Array<string> = [ 'a', 'b' ];
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unused-vars
+function test() {
+	return;
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const arrowFn = ( arg ): string => `test ${ arg }`;
+
+switch ( x[ 0 ] ) {
+// eslint-disable-next-line @stylistic/indent, indent
+case 'a':
+		break;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function foo(): void {}
+foo();
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class Bar {
+	// eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+	animalName: string; // No accessibility modifier
+
+	// eslint-disable-next-line @stylistic/semi
+	private readonly name: string
+
+	// eslint-disable-next-line @typescript-eslint/no-useless-constructor
+	public constructor() {
+		// technically not empty, but useless
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface Example {
+	// eslint-disable-next-line @typescript-eslint/prefer-function-type
+	(): string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface OverloadedExample {
+	y( z: number ): void;
+	// eslint-disable-next-line @typescript-eslint/unified-signatures
+	y( z: string ): void;
+}
+// eslint-disable-next-line @stylistic/type-annotation-spacing, @typescript-eslint/no-unused-vars
+function baz():void {
+	// eslint-disable-next-line @typescript-eslint/no-this-alias
+	const self = this;
+	setTimeout( () => {
+		self.doWork();
+	} );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const myObject: {
+	// eslint-disable-next-line @stylistic/member-delimiter-style
+	a: string,
+	// eslint-disable-next-line @stylistic/member-delimiter-style
+	b: string
+} = {
+	a: 'a',
+	// eslint-disable-next-line comma-dangle
+	b: 'b'
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars
+interface Foo {}

--- a/test/fixtures/typescript/valid.ts
+++ b/test/fixtures/typescript/valid.ts
@@ -1,0 +1,3 @@
+// Both of these rules are replaced by rules that can also handle TypeScript.
+// Off: no-empty-function
+// Off: semi

--- a/typescript.js
+++ b/typescript.js
@@ -16,6 +16,7 @@ module.exports = {
 		}
 	},
 	rules: {
+		'comma-dangle': [ 'error', 'always-multiline' ],
 		// general note: rules not in the TS namespace act in combination with their following line
 		// align recommended w/ wikimedia style or escalating default warnings to errors
 		'@typescript-eslint/array-type': [ 'error', { default: 'array' } ],

--- a/typescript.js
+++ b/typescript.js
@@ -5,7 +5,8 @@ module.exports = {
 		'plugin:@typescript-eslint/recommended'
 	],
 	plugins: [
-		'@typescript-eslint'
+		'@typescript-eslint',
+		'@stylistic'
 	],
 	parserOptions: {
 		parser: '@typescript-eslint/parser',
@@ -26,8 +27,8 @@ module.exports = {
 		'@typescript-eslint/explicit-module-boundary-types': [ 'error' ],
 		'@typescript-eslint/explicit-member-accessibility': [ 'error', { accessibility: 'explicit' } ],
 		// aligned to https://github.com/wikimedia/eslint-config-wikimedia/blob/master/common.json#L21
-		'@typescript-eslint/indent': [ 'error', 'tab', { SwitchCase: 1 } ],
-		'@typescript-eslint/member-delimiter-style': 'error',
+		'@stylistic/indent': [ 'error', 'tab', { SwitchCase: 1 } ],
+		'@stylistic/member-delimiter-style': 'error',
 		'no-empty-function': 'off',
 		'@typescript-eslint/no-empty-function': 'error',
 		'@typescript-eslint/no-empty-interface': [ 'error', { allowSingleExtends: true } ],
@@ -36,7 +37,7 @@ module.exports = {
 		'@typescript-eslint/no-unused-vars': [ 'error', { argsIgnorePattern: '^_' } ],
 		'@typescript-eslint/no-useless-constructor': 'error',
 		'@typescript-eslint/prefer-function-type': 'error',
-		'@typescript-eslint/type-annotation-spacing': [ 'error', {
+		'@stylistic/type-annotation-spacing': [ 'error', {
 			before: false,
 			after: true,
 			overrides: {
@@ -52,6 +53,6 @@ module.exports = {
 		} ],
 		'@typescript-eslint/unified-signatures': 'error',
 		semi: 'off',
-		'@typescript-eslint/semi': [ 'error', 'always' ]
+		'@stylistic/semi': [ 'error', 'always' ]
 	}
 };

--- a/typescript.js
+++ b/typescript.js
@@ -8,8 +8,8 @@ module.exports = {
 		'@typescript-eslint',
 		'@stylistic'
 	],
+	parser: '@typescript-eslint/parser',
 	parserOptions: {
-		parser: '@typescript-eslint/parser',
 		sourceType: 'module',
 		ecmaFeatures: {
 			impliedStrict: true

--- a/typescript.js
+++ b/typescript.js
@@ -1,0 +1,57 @@
+'use strict';
+
+module.exports = {
+	extends: [
+		'plugin:@typescript-eslint/recommended'
+	],
+	plugins: [
+		'@typescript-eslint'
+	],
+	parserOptions: {
+		parser: '@typescript-eslint/parser',
+		sourceType: 'module',
+		ecmaFeatures: {
+			impliedStrict: true
+		}
+	},
+	rules: {
+		// general note: rules not in the TS namespace act in combination with their following line
+		// align recommended w/ wikimedia style or escalating default warnings to errors
+		'@typescript-eslint/array-type': [ 'error', { default: 'array' } ],
+		'@typescript-eslint/explicit-function-return-type': [ 'error', {
+			allowExpressions: true,
+			allowTypedFunctionExpressions: true,
+			allowHigherOrderFunctions: true
+		} ],
+		'@typescript-eslint/explicit-module-boundary-types': [ 'error' ],
+		'@typescript-eslint/explicit-member-accessibility': [ 'error', { accessibility: 'explicit' } ],
+		// aligned to https://github.com/wikimedia/eslint-config-wikimedia/blob/master/common.json#L21
+		'@typescript-eslint/indent': [ 'error', 'tab', { SwitchCase: 1 } ],
+		'@typescript-eslint/member-delimiter-style': 'error',
+		'no-empty-function': 'off',
+		'@typescript-eslint/no-empty-function': 'error',
+		'@typescript-eslint/no-empty-interface': [ 'error', { allowSingleExtends: true } ],
+		'@typescript-eslint/no-this-alias': 'error',
+		// problematic in TypeScript / ES6
+		'@typescript-eslint/no-unused-vars': [ 'error', { argsIgnorePattern: '^_' } ],
+		'@typescript-eslint/no-useless-constructor': 'error',
+		'@typescript-eslint/prefer-function-type': 'error',
+		'@typescript-eslint/type-annotation-spacing': [ 'error', {
+			before: false,
+			after: true,
+			overrides: {
+				arrow: {
+					before: true,
+					after: true
+				},
+				colon: {
+					before: false,
+					after: true
+				}
+			}
+		} ],
+		'@typescript-eslint/unified-signatures': 'error',
+		semi: 'off',
+		'@typescript-eslint/semi': [ 'error', 'always' ]
+	}
+};


### PR DESCRIPTION
This takes over the config from https://github.com/wmde/eslint-config-wikimedia-typescript/ which was explicitly only every intended to be a provisional set of configuration.

This temporary configuration led to problems when its version of this configuration here had to be kept up-to-date or automatic upgrades with LibraryUpgrader would fail, which happened regularly.

This adds the configuration here as a `.js` file, because that allows us to retain the comments in the original file, which are still meaningful. Precedence for `.js` config files already exists in the vue3/ directory.

@typescript-eslint/eslint-plugin and @typescript-eslint/parser are added as direct dependencies in accordance with all the other dependencies that are also direct dependencies like `eslint-plugin-qunit` and so one.

Bug: T301431