### PR TITLE
`typescript`: Fix profile by moving `@stylistic/eslint-plugin` to full dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.30.0",
 			"license": "MIT",
 			"dependencies": {
+				"@stylistic/eslint-plugin": "^3.1.0",
 				"@typescript-eslint/eslint-plugin": "8.35.1",
 				"@typescript-eslint/parser": "8.35.1",
 				"browserslist-config-wikimedia": "^0.7.0",
@@ -30,7 +31,6 @@
 				"eslint-plugin-yml": "^1.14.0"
 			},
 			"devDependencies": {
-				"@stylistic/eslint-plugin": "^3.1.0",
 				"escape-string-regexp": "^4.0.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"qunit": "^2.24.1"
@@ -231,7 +231,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
 			"integrity": "sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/utils": "^8.13.0",
@@ -251,7 +250,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
 			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -264,7 +262,6 @@
 			"version": "10.4.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
 			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"acorn": "^8.15.0",
@@ -282,7 +279,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 	],
 	"license": "MIT",
 	"dependencies": {
+		"@stylistic/eslint-plugin": "^3.1.0",
 		"@typescript-eslint/eslint-plugin": "8.35.1",
 		"@typescript-eslint/parser": "8.35.1",
 		"browserslist-config-wikimedia": "^0.7.0",
@@ -74,7 +75,6 @@
 		"eslint-plugin-yml": "^1.14.0"
 	},
 	"devDependencies": {
-		"@stylistic/eslint-plugin": "^3.1.0",
 		"escape-string-regexp": "^4.0.0",
 		"fs-readdir-recursive": "^1.1.0",
 		"qunit": "^2.24.1"


### PR DESCRIPTION
This was added to dev-dependencies by mistake. It needs to be installed by the downstream repositories that make use of this configuration and so it must be in the normal `"dependencies"`!

This is a follow-up to #623