### PR TITLE
language: Disable es-x/no-iterator-prototype-* rules

### DIFF
--- a/language/rules-es6.json
+++ b/language/rules-es6.json
@@ -21,9 +21,16 @@
 		"unicorn/no-useless-promise-resolve-reject": "error",
 		"es-x/no-symbol-prototype-description": "off",
 		"es-x/no-resizable-and-growable-arraybuffers": "off",
+		"es-x/no-iterator-prototype-drop": "off",
+		"es-x/no-iterator-prototype-every": "off",
+		"es-x/no-iterator-prototype-filter": "off",
+		"es-x/no-iterator-prototype-find": "off",
+		"es-x/no-iterator-prototype-flatmap": "off",
 		"es-x/no-iterator-prototype-foreach": "off",
 		"es-x/no-iterator-prototype-map": "off",
-		"es-x/no-iterator-prototype-filter": "off",
-		"es-x/no-iterator-prototype-find": "off"
+		"es-x/no-iterator-prototype-reduce": "off",
+		"es-x/no-iterator-prototype-some": "off",
+		"es-x/no-iterator-prototype-take": "off",
+		"es-x/no-iterator-prototype-toarray": "off"
 	}
 }

--- a/test/fixtures/client/es6/invalid.js
+++ b/test/fixtures/client/es6/invalid.js
@@ -23,6 +23,11 @@ class MyClass {}
 	// not-es2017 introduces no rules
 
 	// not-es2018
+	// eslint-disable-next-line es-x/no-array-prototype-flat
+	[].flat();
+	// eslint-disable-next-line es-x/no-array-prototype-flat
+	[].flatMap();
+
 	// eslint-disable-next-line es-x/no-string-prototype-trimstart-trimend
 	''.trimEnd();
 	// eslint-disable-next-line es-x/no-object-fromentries

--- a/test/fixtures/client/es6/valid.js
+++ b/test/fixtures/client/es6/valid.js
@@ -85,4 +85,25 @@
 	// with many plain object properties.
 	// Off: es-x/no-symbol-prototype-description
 	window.desc = node.description;
+
+	// Valid: es-x/no-iterator-prototype-drop
+	node.drop();
+	// Valid: es-x/no-iterator-prototype-every
+	node.every();
+	// Valid: es-x/no-iterator-prototype-filter
+	node.filter();
+	// Valid: es-x/no-iterator-prototype-find
+	node.find();
+	// Valid: es-x/no-iterator-prototype-foreach
+	node.forEach();
+	// Valid: es-x/no-iterator-prototype-map
+	node.map();
+	// Valid: es-x/no-iterator-prototype-reduce
+	node.reduce();
+	// Valid: es-x/no-iterator-prototype-some
+	node.some();
+	// Valid: es-x/no-iterator-prototype-take
+	node.take();
+	// Valid: es-x/no-iterator-prototype-toarray
+	node.toArray();
 }() );


### PR DESCRIPTION
These methods are too generically named, and somewhat unnecessary
when Iterator itself is disabled before ES2025.

Fixes #636
