### PR TITLE
jquery/jsdoc: Enable `jQuery` as a global to prevent jsdoc warnings

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -1,6 +1,7 @@
 {
 	"globals": {
-		"$": "readonly"
+		"$": "readonly",
+		"jQuery": "readonly"
 	},
 	"plugins": [ "no-jquery" ],
 	"extends": [

--- a/test/fixtures/jquery/valid.js
+++ b/test/fixtures/jquery/valid.js
@@ -1,5 +1,9 @@
 ( function () {
 
+	// jQuery global is enabled to support jsdoc types, but
+	// shouldn't be used (#639). TODO: Disallow jQuery global.
+	// Global: jQuery
+	jQuery.stop();
 	// Global: $
 	// Valid: no-jquery/no-animate ignores scroll properties
 	$( [] ).animate( { scrollTop: 50 } );

--- a/test/fixtures/jsdoc/.eslintrc.json
+++ b/test/fixtures/jsdoc/.eslintrc.json
@@ -2,6 +2,7 @@
 	"root": true,
 	"extends": [
 		"../../../client/es6",
+		"../../../jquery",
 		"../../../jsdoc"
 	],
 	"rules": {

--- a/test/fixtures/jsdoc/valid.js
+++ b/test/fixtures/jsdoc/valid.js
@@ -138,6 +138,8 @@
 	 * @param {Function} h
 	 * @param {Date} i
 	 * @param {RegExp} j
+	 * @param {jQuery} k
+	 * @param {jQuery.Event} l
 	 * @param {HTMLElement} el HTMLElement is a global provided by the browser environment
 	 * @param {HTMLIFrameElement} iFrame
 	 * @param {Node} domNode


### PR DESCRIPTION
This is a workaround to avoid a flood of new warnings.

In future we should either allow-list specific properties
(e.g. jQuery.{Event|Deferred|Promise}) or write another
rule to disallow the verbose jQuery global.

Fixes #639
