### PR TITLE
mediawiki: Update eslint-plugin-mediawiki to 0.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"eslint-plugin-jest": "^29.0.1",
 				"eslint-plugin-jsdoc": "61.3.0",
 				"eslint-plugin-json-es": "^1.6.0",
-				"eslint-plugin-mediawiki": "^0.8.1",
+				"eslint-plugin-mediawiki": "^0.8.2",
 				"eslint-plugin-mocha": "^10.5.0",
 				"eslint-plugin-n": "^17.23.1",
 				"eslint-plugin-no-jquery": "^3.1.1",
@@ -748,9 +748,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001718",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-			"integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+			"version": "1.0.30001756",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001756.tgz",
+			"integrity": "sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1216,9 +1216,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-mediawiki": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.8.1.tgz",
-			"integrity": "sha512-zjTg3hh375lkztKhOYEmPeYiIhKooAu92BkZf2F/fr+5Htvb2i8MNB3gImhM98aTBbkyHTjXoyTHNUrjSjPhmw==",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.8.2.tgz",
+			"integrity": "sha512-ydYrpkzm8IVVDQA96QPF3HnFd2xjkIEh7gixD2gvOqUbUZF0p36LtpWXOFAlPWAvHLePWbNNTD5ovd3d4hEtog==",
 			"license": "MIT",
 			"dependencies": {
 				"upath": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"eslint-plugin-jest": "^29.0.1",
 		"eslint-plugin-jsdoc": "61.3.0",
 		"eslint-plugin-json-es": "^1.6.0",
-		"eslint-plugin-mediawiki": "^0.8.1",
+		"eslint-plugin-mediawiki": "^0.8.2",
 		"eslint-plugin-mocha": "^10.5.0",
 		"eslint-plugin-n": "^17.23.1",
 		"eslint-plugin-no-jquery": "^3.1.1",


### PR DESCRIPTION
* Rule fix: `no-unlabeled-buttonwidget`: Detect other button classes (Ed Sanders)
* Downgrade best practices to "warn" level by default (Ed Sanders)