### PR TITLE
Pin eslint-plugin-wdio to 9.23.0 and install eslint via peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,14 @@
 		"Oleg Gaidarenko <markelog@gmail.com>"
 	],
 	"license": "MIT",
+	"peerDependencies": {
+		"eslint": "^8.57.0"
+	},
 	"dependencies": {
 		"@stylistic/eslint-plugin": "^3.1.0",
 		"@typescript-eslint/eslint-plugin": "8.54.0",
 		"@typescript-eslint/parser": "8.54.0",
 		"browserslist-config-wikimedia": "^0.7.0",
-		"eslint": "^8.57.0",
 		"eslint-plugin-compat": "^6.1.0",
 		"eslint-plugin-es-x": "^8.7.0",
 		"eslint-plugin-jest": "^29.12.2",
@@ -71,7 +73,7 @@
 		"eslint-plugin-security": "^4.0.0",
 		"eslint-plugin-unicorn": "^56.0.1",
 		"eslint-plugin-vue": "^9.33.0",
-		"eslint-plugin-wdio": "^9.23.0",
+		"eslint-plugin-wdio": "9.23.0",
 		"eslint-plugin-yml": "^1.19.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
* eslint-plugin-wdio 9.25.0 introduces a hard peer dependency on ESLint 9.x. Before that, it was a version-agnostic plugin that worked on both ESLint 8, 9, and presumably 10.

  Note that there was no 9.24.0, due to upstream's monorepo approach. From https://www.npmjs.com/package/eslint-plugin-wdio?activeTab=versions 9.9.1 -> 9.16.2 > 9.23.0 > 9.25.0

* While at it, pin eslint via peerDependencies instead of dependencies so that npm-install fails hard if this ever happens again.

  As it was now, npm-install silently fell back to installing ESLint 9 at the top-level and satisfying eslint-config-wikimedia's apparent needs by installing a second copy under node_modules/eslint-config-wikimedia/node_modules/eslint.

  Then, things only exploded after npm-install with a confusing error message coming from `npm test > eslint .` about incompatible plugins or a missing config file.

  Using a peerDependencies correctly represents the requirement that we don't just use ESLint internally, we actually provide it to the downstream project that uses eslint-config-wikimedia which is expected to be able to call it directly.

  This generally works either way, because npm eagerly de-dupes and hoists whenever it can, but peerDependencies signals that this isn't a nice-to-have, but an intended and required behavior.

Fixes https://github.com/wikimedia/eslint-config-wikimedia/issues/653.