### PR TITLE
build: Fix release.sh to honor preferred names via mailmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+Contributing
+===================
+
+## Release process
+
+1. Draft release commit. You can automate this by running [release.sh](./release.sh).
+   * Create a new branch with a clean checkout out origin/master
+   * Set next version in [package.json](./package.json).
+   * Add release notes section to [CHANGELOG.md](./CHANGELOG.md)
+     Use `npm run -s changelog` to generate it, and improve it
+     as you see fit.
+   * Commit as "Release vX.Y.Z"
+2. Merge release commit
+   * Push branch to remote.
+   * Create pull request.
+   * Wait for CI and code review approval.
+   * Merge into main branch.
+3. Publish git tag and npm package.
+   * Make sure a clean checkout of origin/master, with the merged release commit
+     as its head, e.g. `git show`
+   * Run `git tag -s vX.Y.Z -m "Release"`
+   * Run `git push --follow-tags`
+   * Run `npm publish`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"test": "qunit test/test.js && npm run lint",
 		"lint": "eslint . --max-warnings 0",
+		"changelog": "git log HEAD --format=\"* %s (%aN)\" --no-merges --not --tags | sort",
 		"build-invalid": "node test/test.js dump"
 	},
 	"repository": {

--- a/release.sh
+++ b/release.sh
@@ -71,18 +71,12 @@ npm install --package-lock-only
 
 # == Generate CHANGELOG ==
 
-LAST_TAG=$(get_version_from_git_tag || echo "")
 DATE=$(date +"%Y-%m-%d")
 
-if [ -n "$LAST_TAG" ]; then
-	RAW_COMMITS=$(git log "v$LAST_TAG"..HEAD --pretty=format:'* %s (%an)')
-else
-	RAW_COMMITS=$(git log --pretty=format:'* %s (%an)')
-fi
+RAW_COMMITS=$(npm run -s changelog)
 
 COMMITS=$(printf "%s\n" "$RAW_COMMITS" |
-	sed -E 's/\s*\(#([0-9]+)\)//g' |             # remove github ticket (#123)
-	sed -E 's/\(Ed S\)/(Ed Sanders)/g'           # expand names
+	sed -E 's/\s*\(#([0-9]+)\)//g'               # remove github ticket (#123)
 )
 
 HEADLINE="$NEW_VERSION / $DATE"


### PR DESCRIPTION
Use `%aN` instead of `%an` which honors the mailmap. This matches what we already do in npm and composer packages hosted in Wikimedia Gerrit via commands like `composer changelog` [1]

This removes the need to manually expand Ed's name, since this is in the mailmap already.

Document the rest of the release process while at it.

[1] https://codesearch.wmcloud.org/search/?q=%22changelog%22&files=%5E%28composer.json%7Cpackage.json%29&excludeFiles=&repos=