### PR TITLE
jquery: Upgrade eslint-plugin-no-jquery to 6.0.0; raise target deprecations to jQuery 4.0

### DIFF
--- a/jquery.json
+++ b/jquery.json
@@ -22,6 +22,7 @@
 		"no-jquery/no-global-selector": "error",
 		"no-jquery/no-grep": "error",
 		"no-jquery/no-in-array": "error",
+		"no-jquery/no-jquery-ui": "error",
 		"no-jquery/no-map-util": "error",
 		"no-jquery/no-noop": "error",
 		"no-jquery/no-parse-html-literal": "error",

--- a/jquery.json
+++ b/jquery.json
@@ -6,7 +6,7 @@
 	"plugins": [ "no-jquery" ],
 	"extends": [
 		"plugin:no-jquery/recommended",
-		"plugin:no-jquery/deprecated-3.7"
+		"plugin:no-jquery/deprecated-4.0"
 	],
 	"rules": {
 		"no-jquery/no-animate": [ "error", { "allowScroll": true } ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"eslint-plugin-mediawiki": "^0.8.3",
 				"eslint-plugin-mocha": "^10.5.0",
 				"eslint-plugin-n": "^17.24.0",
-				"eslint-plugin-no-jquery": "^5.0.0",
+				"eslint-plugin-no-jquery": "^6.0.0",
 				"eslint-plugin-qunit": "^8.2.6",
 				"eslint-plugin-security": "^4.0.0",
 				"eslint-plugin-unicorn": "^56.0.1",
@@ -1351,9 +1351,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-no-jquery": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-5.0.0.tgz",
-			"integrity": "sha512-DeWR+8HnFoOenyfWEqNkjAk2AVhEUA6oa3n4ZnFbJIB3AXeau/i9DNWV6c83b5SzXZ8L8PW59EARA8Xtc8eoag==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-6.0.0.tgz",
+			"integrity": "sha512-LgFjg9SS2faXhcJGtzVocsQT9DXNTW+M5GVLUfSneuX9KG4G+Dnk1RwhxEEsi0rNp3sQ/73OcUM1Eo/bJ6O75A==",
 			"license": "MIT",
 			"peerDependencies": {
 				"eslint": ">=8.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"eslint-plugin-mediawiki": "^0.8.3",
 		"eslint-plugin-mocha": "^10.5.0",
 		"eslint-plugin-n": "^17.24.0",
-		"eslint-plugin-no-jquery": "^5.0.0",
+		"eslint-plugin-no-jquery": "^6.0.0",
 		"eslint-plugin-qunit": "^8.2.6",
 		"eslint-plugin-security": "^4.0.0",
 		"eslint-plugin-unicorn": "^56.0.1",

--- a/test/fixtures/jquery/invalid.js
+++ b/test/fixtures/jquery/invalid.js
@@ -74,6 +74,21 @@
 	div.hide();
 
 	// Deprecated
+
+	/* 4.0 */
+	// eslint-disable-next-line no-jquery/no-internal-array-methods, no-jquery/no-global-selector
+	$( 'div' ).sort();
+
+	/* 3.7 */
+	// eslint-disable-next-line no-jquery/no-deferred-get-stack-hook
+	$.Deferred.getStackHook;
+
+	// eslint-disable-next-line no-jquery/no-css-number
+	$.cssNumber;
+
+	// eslint-disable-next-line no-jquery/no-css-props
+	$.cssProps;
+
 	/* 3.5 */
 	// eslint-disable-next-line no-jquery/no-event-shorthand
 	$x.ajaxStart();

--- a/test/fixtures/jquery/invalid.js
+++ b/test/fixtures/jquery/invalid.js
@@ -46,6 +46,9 @@
 	// eslint-disable-next-line no-jquery/no-in-array
 	$.inArray( 1, [ 1 ] );
 
+	// eslint-disable-next-line no-jquery/no-jquery-ui
+	$( [] ).draggable();
+
 	// eslint-disable-next-line no-jquery/no-map-util
 	$.map( [ 1 ], () => {} );
 


### PR DESCRIPTION
Done as two commits in case you think the 4.0 jump is premature (even if it's a no-op).